### PR TITLE
Add link to the source code in the documentation

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -9,6 +9,8 @@ Syncs Cardano blockchain information a Postgres database.
 - Backend: written in Rust using [Oura](https://github.com/txpipe/oura) and [CML](https://github.com/dcSpark/cardano-multiplatform-lib).
 - Sever & Client: Written using Typescript
 
+The source code can be found here on github: [dcSpark/carp](https://github.com/dcSpark/carp).
+
 # Core pillars
 
 - **Speed**: queries should be fast so they can be used inside production applications like wallets without the user feeling the application is not responsive.


### PR DESCRIPTION
It feels that this is missing completely. Users looking at the documentation may not have the directly link to the repository. We can add it at the beginning of the documentation so that it's pretty much direct and users can checkout the code early.