### PR TITLE
[WiP] Adding support for custom execution plan

### DIFF
--- a/indexer/plan-visualizer/src/main.rs
+++ b/indexer/plan-visualizer/src/main.rs
@@ -36,7 +36,7 @@ fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
     tracing::info!("Execution plan {}", args.plan);
-    let exec_plan = ExecutionPlan::load_from_file(&args.plan);
+    let exec_plan = ExecutionPlan::load_execution_plan(&args.plan);
     let plan_name = Path::new(&args.plan).file_stem().unwrap().to_str().unwrap();
 
     let graph = generate(&exec_plan, plan_name);

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -57,7 +57,7 @@ async fn main() -> anyhow::Result<()> {
     let postgres_url = std::env::var("DATABASE_URL").expect("env DATABASE_URL not found");
 
     tracing::info!("Execution plan {}", args.plan);
-    let exec_plan = Arc::new(ExecutionPlan::load_from_file(&args.plan));
+    let exec_plan = Arc::new(ExecutionPlan::load_execution_plan(&args.plan));
 
     tracing::info!("{}", "Connecting to database...");
     let conn = Database::connect(&postgres_url).await?;

--- a/indexer/tasks/src/execution_plan.rs
+++ b/indexer/tasks/src/execution_plan.rs
@@ -19,4 +19,28 @@ impl ExecutionPlan {
             }
         }
     }
+    pub fn load_from_ipfs(url: &str) -> ExecutionPlan {
+        // TODO: not ready! just a placeholder
+        match &fs::read_to_string(url) {
+            Ok(execution_plan_content) => {
+                let setting: Result<toml::value::Table, toml::de::Error> =
+                    toml::from_str(execution_plan_content);
+
+                ExecutionPlan(setting.unwrap())
+            }
+            Err(err) => {
+                tracing::error!("No execution plan found at {}", url);
+                panic!("{}", err);
+            }
+        }
+    }
+
+    pub fn load_execution_plan(path: &str) -> ExecutionPlan {
+        if path.starts_with("https://") || path.starts_with("http://"){
+            return ExecutionPlan::load_from_ipfs(path);
+        } else {
+            return ExecutionPlan::load_from_file(path);
+        }
+
+    }
 }


### PR DESCRIPTION
Working on https://github.com/dcSpark/carp/issues/41

TODO:
- [] Read default.toml execution plan as previously
- [] Read file given as parameter
- [] Fetch execution plan from IPFS
- [] Set behaviour depending on input string protocol (http/none)