### PR TITLE
Fix handling of exact bech32 addresses in history endpoint

### DIFF
--- a/webserver/server/app/models/utils.ts
+++ b/webserver/server/app/models/utils.ts
@@ -31,10 +31,16 @@ export const getAddressTypes = (addresses: string[]): ParsedAddressTypes => {
       updateSet(asCredHex, address);
       continue;
     }
-    const asExactAddressHex = getAsCredentialHex(address);
-    if (asExactAddressHex != null) {
-      result.credentialHex.push(asExactAddressHex);
-      updateSet(asExactAddressHex, address);
+    const asCredentialHex = getAsCredentialHex(address);
+    if (asCredentialHex != null) {
+      result.credentialHex.push(asCredentialHex);
+      updateSet(asCredentialHex, address);
+      continue;
+    }
+    const asExactAddress = getAsExactAddressHex(address);
+    if (asExactAddress != null) {
+      result.exactAddress.push(asExactAddress);
+      updateSet(asExactAddress, address);
       continue;
     }
 


### PR DESCRIPTION
https://github.com/dcSpark/carp/pull/73 accidentally broke tx history queries for exact bech32 addresses