### PR TITLE
Fix ordering of member variables in transaction/output

### DIFF
--- a/webserver/examples/tests/transactionOutput.test.ts
+++ b/webserver/examples/tests/transactionOutput.test.ts
@@ -30,8 +30,8 @@ describe(`/${Routes.transactionOutput}`, function () {
       {
         utxo: {
           txHash:
-            "7775d5e094b3660cae2464da5ba029134bfa9ca410cc3c7198d23731855bc3d0",
-          index: 0,
+            "00001781e639bdf53cdac97ebbaf43035b35ce59be9f6e480e7b46dcd5c67028",
+          index: 4,
           payload:
             "82582b82d818582183581c962e3a277a62aafd441e9d0e98d79be3d25db0aa57feb7daf52777e3a0001a6acabec11a07794402",
         },
@@ -48,8 +48,8 @@ describe(`/${Routes.transactionOutput}`, function () {
       {
         utxo: {
           txHash:
-            "00001781e639bdf53cdac97ebbaf43035b35ce59be9f6e480e7b46dcd5c67028",
-          index: 4,
+            "7775d5e094b3660cae2464da5ba029134bfa9ca410cc3c7198d23731855bc3d0",
+          index: 0,
           payload:
             "82581d6100000000000000000000000000000000000000000000000000000000821a0014851ea1581cdb01dec7311778ad90b72627a38cd6ec61a298f964d2320b4a67c23ba14356495001",
         },

--- a/webserver/server/app/models/transaction/sqlTransactionOutput.queries.ts
+++ b/webserver/server/app/models/transaction/sqlTransactionOutput.queries.ts
@@ -16,8 +16,10 @@ export interface ISqlTransactionOutputResult {
   block_hash: Buffer;
   epoch: number;
   era: number;
+  hash: Buffer;
   height: number;
   is_valid: boolean;
+  output_index: number;
   slot: number;
   tx_index: number;
   utxo_payload: Buffer;
@@ -29,7 +31,7 @@ export interface ISqlTransactionOutputQuery {
   result: ISqlTransactionOutputResult;
 }
 
-const sqlTransactionOutputIR: any = {"name":"sqlTransactionOutput","params":[{"name":"tx_hash","required":false,"transform":{"type":"scalar"},"codeRefs":{"used":[{"a":110,"b":116,"line":6,"col":8}]}},{"name":"output_index","required":false,"transform":{"type":"scalar"},"codeRefs":{"used":[{"a":137,"b":148,"line":7,"col":8}]}}],"usedParamSet":{"tx_hash":true,"output_index":true},"statement":{"body":"WITH pointers AS (\n  SELECT tx_hash, output_index\n  FROM\n    unnest(\n      (:tx_hash)::bytea[],\n      (:output_index)::int[]\n    ) x(tx_hash,output_index)\n)\nSELECT\n  \"TransactionOutput\".payload as utxo_payload,\n  \"Transaction\".is_valid,\n  \"Transaction\".tx_index,\n  \"Block\".hash AS block_hash,\n  \"Block\".epoch,\n  \"Block\".slot,\n  \"Block\".era,\n  \"Block\".height\nFROM\n  \"Transaction\"\n  INNER JOIN \"TransactionOutput\" ON \"Transaction\".id = \"TransactionOutput\".tx_id\n  INNER JOIN \"Block\" on \"Block\".id = \"Transaction\".block_id\nWHERE (\"Transaction\".hash, \"TransactionOutput\".output_index) in (SELECT tx_hash, output_index FROM pointers)","loc":{"a":33,"b":660,"line":2,"col":0}}};
+const sqlTransactionOutputIR: any = {"name":"sqlTransactionOutput","params":[{"name":"tx_hash","required":false,"transform":{"type":"scalar"},"codeRefs":{"used":[{"a":110,"b":116,"line":6,"col":8}]}},{"name":"output_index","required":false,"transform":{"type":"scalar"},"codeRefs":{"used":[{"a":137,"b":148,"line":7,"col":8}]}}],"usedParamSet":{"tx_hash":true,"output_index":true},"statement":{"body":"WITH pointers AS (\n  SELECT tx_hash, output_index\n  FROM\n    unnest(\n      (:tx_hash)::bytea[],\n      (:output_index)::int[]\n    ) x(tx_hash,output_index)\n)\nSELECT\n  \"TransactionOutput\".payload as utxo_payload,\n  \"Transaction\".is_valid,\n  \"Transaction\".tx_index,\n  \"Transaction\".hash,\n  \"Block\".hash AS block_hash,\n  \"Block\".epoch,\n  \"Block\".slot,\n  \"Block\".era,\n  \"Block\".height,\n  \"TransactionOutput\".output_index\nFROM\n  \"Transaction\"\n  INNER JOIN \"TransactionOutput\" ON \"Transaction\".id = \"TransactionOutput\".tx_id\n  INNER JOIN \"Block\" on \"Block\".id = \"Transaction\".block_id\nWHERE (\"Transaction\".hash, \"TransactionOutput\".output_index) in (SELECT tx_hash, output_index FROM pointers)","loc":{"a":33,"b":718,"line":2,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -46,11 +48,13 @@ const sqlTransactionOutputIR: any = {"name":"sqlTransactionOutput","params":[{"n
  *   "TransactionOutput".payload as utxo_payload,
  *   "Transaction".is_valid,
  *   "Transaction".tx_index,
+ *   "Transaction".hash,
  *   "Block".hash AS block_hash,
  *   "Block".epoch,
  *   "Block".slot,
  *   "Block".era,
- *   "Block".height
+ *   "Block".height,
+ *   "TransactionOutput".output_index
  * FROM
  *   "Transaction"
  *   INNER JOIN "TransactionOutput" ON "Transaction".id = "TransactionOutput".tx_id

--- a/webserver/server/app/models/transaction/sqlTransactionOutput.sql
+++ b/webserver/server/app/models/transaction/sqlTransactionOutput.sql
@@ -11,11 +11,13 @@ SELECT
   "TransactionOutput".payload as utxo_payload,
   "Transaction".is_valid,
   "Transaction".tx_index,
+  "Transaction".hash,
   "Block".hash AS block_hash,
   "Block".epoch,
   "Block".slot,
   "Block".era,
-  "Block".height
+  "Block".height,
+  "TransactionOutput".output_index
 FROM
   "Transaction"
   INNER JOIN "TransactionOutput" ON "Transaction".id = "TransactionOutput".tx_id

--- a/webserver/server/app/services/TransactionOutput.ts
+++ b/webserver/server/app/services/TransactionOutput.ts
@@ -19,20 +19,20 @@ export async function outputsForTransaction(
     request.dbTx
   );
   return {
-    utxos: utxos.map(({ utxo_payload, ...block }, i) => ({
+    utxos: utxos.map(db_utxo => ({
       utxo: {
-        txHash: request.utxoPointers[i].txHash,
-        index: request.utxoPointers[i].index,
-        payload: utxo_payload.toString('hex'),
+        txHash: db_utxo.hash.toString('hex'),
+        index: db_utxo.output_index,
+        payload: db_utxo.utxo_payload.toString('hex'),
       },
       block: {
-        height: block.height,
-        hash: block.block_hash.toString('hex'),
-        epoch: block.epoch,
-        slot: block.slot,
-        era: block.era,
-        indexInBlock: block.tx_index,
-        isValid: block.is_valid,
+        height: db_utxo.height,
+        hash: db_utxo.block_hash.toString('hex'),
+        epoch: db_utxo.epoch,
+        slot: db_utxo.slot,
+        era: db_utxo.era,
+        indexInBlock: db_utxo.tx_index,
+        isValid: db_utxo.is_valid,
       },
     })),
   };


### PR DESCRIPTION
The `transaction/output` endpoint was making some incorrect assumptions about the ordering of results causing the a <tx_hash, index> pair to sometimes point to the wrong payload/block.

This PR fixes this. Note that this change will affect the order of the results of the `transaction/output` endpoint