### PR TITLE
Improve speed of last price endpoint

### DIFF
--- a/webserver/server/app/models/dex/sqlDexLastPrice.sql
+++ b/webserver/server/app/models/dex/sqlDexLastPrice.sql
@@ -1,51 +1,68 @@
 /* @name sqlDexLastPrice */
-WITH "AssetPairs" AS (
-  SELECT policy_id1, asset_name1, policy_id2, asset_name2
-  FROM
-    unnest(
-      /*
-      Aparrently, we can't make pgtyped understand that these are actually (bytea | NULL)[].
-      We will pass in ('', '') instead of (NULL, NULL) for ADA and do the NULL->'' conversion
-      below when filtering the assets (see the COALESCE).
-      */
-      (:policy_id1)::bytea[],
-      (:asset_name1)::bytea[],
-      (:policy_id2)::bytea[],
-      (:asset_name2)::bytea[]
-    ) x(policy_id1, asset_name1, policy_id2, asset_name2)
-)
+WITH
+  "AssetPairs" AS (
+      SELECT policy_id1, asset_name1, policy_id2, asset_name2
+      FROM
+        unnest(
+          /*
+          Aparrently, we can't make pgtyped understand that these are actually (bytea | NULL)[].
+          We will pass in ('', '') instead of (NULL, NULL) for ADA and do the NULL->'' conversion
+          below when filtering the assets (see the COALESCE).
+          */
+          (:policy_id1)::bytea[],
+          (:asset_name1)::bytea[],
+          (:policy_id2)::bytea[],
+          (:asset_name2)::bytea[]
+        ) x(policy_id1, asset_name1, policy_id2, asset_name2)
+  ),
+  "AssetIdPairs" AS (
+        SELECT "AssetPairs".*, "Asset1".id as "asset1_id", "Asset2".id as "asset2_id"
+        FROM "AssetPairs"
+        LEFT JOIN "NativeAsset" as "Asset1" ON "Asset1".policy_id = "AssetPairs".policy_id1 AND "Asset1".asset_name = "AssetPairs".asset_name1
+        LEFT JOIN "NativeAsset" as "Asset2" ON "Asset2".policy_id = "AssetPairs".policy_id2 AND "Asset2".asset_name = "AssetPairs".asset_name2
+  ),
+  "DexWithAssets" AS (
+        SELECT
+        "Asset1".policy_id1 AS "policy_id1?",
+        "Asset1".asset_name1 AS "asset_name1?",
+        "Asset2".policy_id2 AS "policy_id2?",
+        "Asset2".asset_name2 AS "asset_name2?",
+        "Dex".asset1_id,
+        "Dex".asset2_id,
+        "Dex".amount1,
+        "Dex".amount2,
+        "Dex".dex,
+        "Dex".id,
+        "Dex".tx_id
+        FROM "Dex"
+        INNER JOIN "AssetIdPairs" as "Asset1"
+        ON
+              COALESCE("Dex".asset1_id, -1) = COALESCE("Asset1".asset1_id, -1) 
+              AND
+              COALESCE("Dex".asset2_id, -1) = COALESCE("Asset1".asset2_id, -1)
+              AND
+              "Dex".operation = :operation1
+        -- Add swap for another direction
+        INNER JOIN "AssetIdPairs" as "Asset2"
+        ON
+              COALESCE("Dex".asset2_id, -1) = COALESCE("Asset2".asset2_id, -1)
+              AND
+              COALESCE("Dex".asset1_id, -1) = COALESCE("Asset2".asset1_id, -1)
+              AND "Dex".operation = :operation2
+  )
 SELECT
-  DISTINCT ON("Dex".dex)
-
-  "Asset1".policy_id AS "policy_id1?",
-  "Asset1".asset_name AS "asset_name1?",
-  "Asset2".policy_id AS "policy_id2?",
-  "Asset2".asset_name AS "asset_name2?",
-  "Dex".amount1,
-  "Dex".amount2,
-  "Dex".dex
-FROM "Dex"
-LEFT JOIN "NativeAsset" as "Asset1" ON "Asset1".id = "Dex".asset1_id
-LEFT JOIN "NativeAsset" as "Asset2" ON "Asset2".id = "Dex".asset2_id
-WHERE
-  (
-    (
-      COALESCE("Asset1".policy_id, ''::bytea),
-      COALESCE("Asset1".asset_name, ''::bytea),
-      COALESCE("Asset2".policy_id, ''::bytea),
-      COALESCE("Asset2".asset_name, ''::bytea)
-    ) IN (SELECT policy_id1, asset_name1, policy_id2, asset_name2 FROM "AssetPairs")
-    AND "Dex".operation = :operation1
-  )
-  -- Add swap for another direction
-  OR
-  (
-    (
-      COALESCE("Asset2".policy_id, ''::bytea),
-      COALESCE("Asset2".asset_name, ''::bytea),
-      COALESCE("Asset1".policy_id, ''::bytea),
-      COALESCE("Asset1".asset_name, ''::bytea)
-    ) IN (SELECT policy_id1, asset_name1, policy_id2, asset_name2 FROM "AssetPairs")
-    AND "Dex".operation = :operation2
-  )
-ORDER BY "Dex".dex, "Dex".tx_id DESC, "Dex".id DESC;
+      a.*,
+      "Block".hash as "block_hash",
+      "Block".height,
+      "Block".epoch,
+      "Block".slot
+FROM "DexWithAssets" a
+INNER JOIN (
+      SELECT
+      "DexWithAssets".dex, "DexWithAssets".asset1_id, "DexWithAssets".asset2_id,
+      MAX("DexWithAssets".id) as "id"
+      FROM "DexWithAssets"
+      GROUP BY "DexWithAssets".dex, "DexWithAssets".asset1_id, "DexWithAssets".asset2_id
+) b ON a.id = b.id
+LEFT JOIN "Transaction" ON "Transaction".id = a.tx_id
+LEFT JOIN "Block" ON "Block".id = "Transaction".block_id;

--- a/webserver/server/app/services/DexLastPrice.ts
+++ b/webserver/server/app/services/DexLastPrice.ts
@@ -5,48 +5,53 @@ import { PriceType } from '../../../shared/models/DexLastPrice';
 import { sqlDexLastPrice } from '../models/dex/sqlDexLastPrice.queries';
 import { parseAssetItem, serializeAsset, valueToDex } from './utils';
 
-
-export async function dexLastPrice(
-  request: {
-    dbTx: PoolClient;
-    assetPairs: { asset1: Asset, asset2: Asset }[];
-    type: PriceType;
-  }
-): Promise<DexLastPriceResponse> {
+export async function dexLastPrice(request: {
+  dbTx: PoolClient;
+  assetPairs: { asset1: Asset; asset2: Asset }[];
+  type: PriceType;
+}): Promise<DexLastPriceResponse> {
   if (request.assetPairs.length === 0) return { lastPrice: [] };
-
 
   const lastPrice = await (async () => {
     switch (request.type) {
       case PriceType.Mean:
-        return await sqlDexLastPrice.run({
-          policy_id1: request.assetPairs.map(pair => parseAssetItem(pair.asset1?.policyId)),
-          asset_name1: request.assetPairs.map(pair => parseAssetItem(pair.asset1?.assetName)),
-          policy_id2: request.assetPairs.map(pair => parseAssetItem(pair.asset2?.policyId)),
-          asset_name2: request.assetPairs.map(pair => parseAssetItem(pair.asset2?.assetName)),
-          operation1: '2',
-          operation2: '2'
-        }, request.dbTx);
+        return await sqlDexLastPrice.run(
+          {
+            policy_id1: request.assetPairs.map(pair => parseAssetItem(pair.asset1?.policyId)),
+            asset_name1: request.assetPairs.map(pair => parseAssetItem(pair.asset1?.assetName)),
+            policy_id2: request.assetPairs.map(pair => parseAssetItem(pair.asset2?.policyId)),
+            asset_name2: request.assetPairs.map(pair => parseAssetItem(pair.asset2?.assetName)),
+            operation1: '2',
+            operation2: '2',
+          },
+          request.dbTx
+        );
 
       case PriceType.Sell:
-        return await sqlDexLastPrice.run({
-          policy_id1: request.assetPairs.map(pair => parseAssetItem(pair.asset1?.policyId)),
-          asset_name1: request.assetPairs.map(pair => parseAssetItem(pair.asset1?.assetName)),
-          policy_id2: request.assetPairs.map(pair => parseAssetItem(pair.asset2?.policyId)),
-          asset_name2: request.assetPairs.map(pair => parseAssetItem(pair.asset2?.assetName)),
-          operation1: '0',
-          operation2: '1'
-        }, request.dbTx);
+        return await sqlDexLastPrice.run(
+          {
+            policy_id1: request.assetPairs.map(pair => parseAssetItem(pair.asset1?.policyId)),
+            asset_name1: request.assetPairs.map(pair => parseAssetItem(pair.asset1?.assetName)),
+            policy_id2: request.assetPairs.map(pair => parseAssetItem(pair.asset2?.policyId)),
+            asset_name2: request.assetPairs.map(pair => parseAssetItem(pair.asset2?.assetName)),
+            operation1: '0',
+            operation2: '1',
+          },
+          request.dbTx
+        );
 
       case PriceType.Buy:
-        return await sqlDexLastPrice.run({
-          policy_id1: request.assetPairs.map(pair => parseAssetItem(pair.asset1?.policyId)),
-          asset_name1: request.assetPairs.map(pair => parseAssetItem(pair.asset1?.assetName)),
-          policy_id2: request.assetPairs.map(pair => parseAssetItem(pair.asset2?.policyId)),
-          asset_name2: request.assetPairs.map(pair => parseAssetItem(pair.asset2?.assetName)),
-          operation1: '1',
-          operation2: '0'
-        }, request.dbTx);
+        return await sqlDexLastPrice.run(
+          {
+            policy_id1: request.assetPairs.map(pair => parseAssetItem(pair.asset1?.policyId)),
+            asset_name1: request.assetPairs.map(pair => parseAssetItem(pair.asset1?.assetName)),
+            policy_id2: request.assetPairs.map(pair => parseAssetItem(pair.asset2?.policyId)),
+            asset_name2: request.assetPairs.map(pair => parseAssetItem(pair.asset2?.assetName)),
+            operation1: '1',
+            operation2: '0',
+          },
+          request.dbTx
+        );
     }
   })();
 
@@ -56,7 +61,13 @@ export async function dexLastPrice(
       asset2: serializeAsset(result.policy_id2, result.asset_name2),
       amount1: result.amount1,
       amount2: result.amount2,
-      dex: valueToDex(result.dex)
+      dex: valueToDex(result.dex),
+      block: {
+        hash: result.block_hash.toString('hex'),
+        height: result.height,
+        epoch: result.epoch,
+        slot: result.slot,
+      },
     })),
   };
 }

--- a/webserver/shared/models/DexLastPrice.ts
+++ b/webserver/shared/models/DexLastPrice.ts
@@ -1,24 +1,26 @@
+import { BlockSubset } from "./BlockLatest";
 import { Dex, Asset, Amount } from "./common";
 
 export type DexLastPrice = {
-    asset1: Asset;
-    asset2: Asset;
-    amount1: Amount;
-    amount2: Amount;
-    dex: Dex;
+  asset1: Asset;
+  asset2: Asset;
+  amount1: Amount;
+  amount2: Amount;
+  dex: Dex;
+  block: Omit<BlockSubset, "era">;
 };
 
 export enum PriceType {
-    Buy = "buy",
-    Sell = "sell",
-    /**
-     * Mean is not AVG from the last values, but the remaining amount of assets on the pool output
-     */
-    Mean = "mean",
-};
+  Buy = "buy",
+  Sell = "sell",
+  /**
+   * Mean is not AVG from the last values, but the remaining amount of assets on the pool output
+   */
+  Mean = "mean",
+}
 
 export type DexLastPriceRequest = {
-  assetPairs: {asset1: Asset, asset2: Asset}[];
+  assetPairs: { asset1: Asset; asset2: Asset }[];
   type: PriceType;
 };
 


### PR DESCRIPTION
This re-implementation of the last price endpoint has the following differences:

1. It now returns information about the block where the last price change happened so you can know how long ago it was
2. It's about 100x faster than the old query

Unfortunately there are no tests for this endpoint, so I instead manually tested some queries and it gave the same output. It would be good to test this against a fully sync'd instance and compare the result to know truths (real DEX prices)