### PR TITLE
Fixes for: multiple NFTs claim and partial withdrawal connection history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,11 +137,11 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c"
 dependencies = [
- "async-lock 3.1.2",
+ "async-lock 3.2.0",
  "async-task",
  "concurrent-queue",
  "fastrand 2.0.1",
- "futures-lite 2.0.1",
+ "futures-lite 2.1.0",
  "slab",
 ]
 
@@ -154,9 +154,9 @@ dependencies = [
  "async-channel 2.1.1",
  "async-executor",
  "async-io 2.2.1",
- "async-lock 3.1.2",
+ "async-lock 3.2.0",
  "blocking",
- "futures-lite 2.0.1",
+ "futures-lite 2.1.0",
  "once_cell",
  "tokio",
 ]
@@ -187,14 +187,14 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6d3b15875ba253d1110c740755e246537483f152fa334f91abd7fe84c88b3ff"
 dependencies = [
- "async-lock 3.1.2",
+ "async-lock 3.2.0",
  "cfg-if 1.0.0",
  "concurrent-queue",
  "futures-io",
- "futures-lite 2.0.1",
+ "futures-lite 2.1.0",
  "parking",
  "polling 3.3.1",
- "rustix 0.38.25",
+ "rustix 0.38.26",
  "slab",
  "tracing",
  "windows-sys 0.52.0",
@@ -211,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.1.2"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea8b3453dd7cc96711834b75400d671b73e3656975fa68d9f277163b7f7e316"
+checksum = "7125e42787d53db9dd54261812ef17e937c95a51e4d291373b670342fa44310c"
 dependencies = [
  "event-listener 4.0.0",
  "event-listener-strategy",
@@ -451,11 +451,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
 dependencies = [
  "async-channel 2.1.1",
- "async-lock 3.1.2",
+ "async-lock 3.2.0",
  "async-task",
  "fastrand 2.0.1",
  "futures-io",
- "futures-lite 2.0.1",
+ "futures-lite 2.1.0",
  "piper",
  "tracing",
 ]
@@ -835,9 +835,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f057a694a54f12365049b0958a1685bb52d567f5593b355fbf685838e873d400"
+checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -866,9 +866,9 @@ checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "cpufeatures"
@@ -1063,9 +1063,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
+checksum = "8eb30d70a07a3b04884d2677f06bec33509dc67ca60d92949e5535352d3191dc"
 dependencies = [
  "powerfmt",
 ]
@@ -1201,12 +1201,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f258a7194e7f7c2a7837a8913aeab7fd8c383457034fa20ce4dd3dcb813e8eb8"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1380,14 +1380,13 @@ dependencies = [
 
 [[package]]
 name = "futures-lite"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3831c2651acb5177cbd83943f3d9c8912c5ad03c76afcc0e9511ba568ec5ebb"
+checksum = "aeee267a1883f7ebef3700f262d2d54de95dfaf38189015a74fdc4e0c7ad8143"
 dependencies = [
  "fastrand 2.0.1",
  "futures-core",
  "futures-io",
- "memchr",
  "parking",
  "pin-project-lite",
 ]
@@ -1748,7 +1747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.3",
- "rustix 0.38.25",
+ "rustix 0.38.26",
  "windows-sys 0.48.0",
 ]
 
@@ -1822,9 +1821,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
+checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
 name = "lock_api"
@@ -1973,9 +1972,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
  "log",
@@ -2527,7 +2526,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "concurrent-queue",
  "pin-project-lite",
- "rustix 0.38.25",
+ "rustix 0.38.26",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -2546,10 +2545,11 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
+checksum = "97dc5fea232fc28d2f597b37c4876b348a40e33f3b02cc975c8d006d78d94b1a"
 dependencies = [
+ "toml_datetime",
  "toml_edit",
 ]
 
@@ -2985,15 +2985,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.25"
+version = "0.38.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
+checksum = "9470c4bf8246c8daf25f9598dca807fb6510347b1e1cfa55749113850c79d88a"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
  "libc",
- "linux-raw-sys 0.4.11",
- "windows-sys 0.48.0",
+ "linux-raw-sys 0.4.12",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3952,15 +3952,15 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 
 [[package]]
 name = "toml_edit"
-version = "0.20.7"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap 2.1.0",
  "toml_datetime",
@@ -4505,9 +4505,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.19"
+version = "0.5.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
+checksum = "b7e87b8dfbe3baffbe687eef2e164e32286eff31a5ee16463ce03d991643ec94"
 dependencies = [
  "memchr",
 ]

--- a/indexer/tasks/src/config/AddressConfig.rs
+++ b/indexer/tasks/src/config/AddressConfig.rs
@@ -3,6 +3,6 @@ use pallas::ledger::primitives::alonzo::PlutusScript;
 use pallas::ledger::primitives::babbage::PlutusV2Script;
 
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
-pub struct PayloadAndReadonlyConfig {
+pub struct AddressConfig {
     pub address: String,
 }

--- a/indexer/tasks/src/multiera/multiera_projected_nft.rs
+++ b/indexer/tasks/src/multiera/multiera_projected_nft.rs
@@ -124,7 +124,7 @@ async fn handle_projected_nft(
     let mut queued_projected_nft_records = vec![];
 
     for (tx_body, cardano_transaction) in block.1.txs().iter().zip(multiera_txs) {
-        // redeemers are needed to identify whil of the projected nfts are partial withdrawals
+        // redeemers are needed to identify which of the projected nfts are partial withdrawals
         let redeemers = tx_body
             .redeemers()
             .map(get_projected_nft_redeemers)

--- a/indexer/tasks/src/multiera/multiera_projected_nft.rs
+++ b/indexer/tasks/src/multiera/multiera_projected_nft.rs
@@ -129,7 +129,7 @@ async fn handle_projected_nft(
             .redeemers()
             .map(get_projected_nft_redeemers)
             .unwrap_or(Ok(BTreeMap::new()))?;
-        tracing::info!("Redeemers: {:?}", redeemers.iter().collect::<Vec<_>>());
+
         // partial withdrawals inputs -- inputs which have partial withdraw = true in the redeemer
         // this function also adds claims to the events list
         let mut partial_withdrawals_inputs = handle_claims_and_partial_withdraws(
@@ -185,34 +185,7 @@ async fn handle_projected_nft(
 
             projected_nft_outputs.push(projected_nft_data);
         }
-        for projected_nft_output in projected_nft_outputs.iter() {
-            for (asset_name, asset_value) in projected_nft_output.non_ada_assets.iter() {
-                tracing::info!(
-                    "projected nft output: op: {:?}, partial: {}\nasset: {:?}\nvalue: {:?}\nprev tx: {:?}@{:?}",
-                    projected_nft_output.operation,
-                    projected_nft_output.partial_withdrawn_from_input.is_some(),
-                    asset_name,
-                    asset_value,
-                    hex::encode(projected_nft_output.previous_utxo_tx_hash.clone()),
-                    projected_nft_output.previous_utxo_tx_output_index,
-                );
-            }
-        }
 
-        for (tx, withdrawal) in partial_withdrawals_inputs.iter() {
-            for (index, withdrawal) in withdrawal.iter() {
-                for withdrawal in withdrawal.iter() {
-                    tracing::info!(
-                        "projected nft withdrawal: tx: {:?}@{:?}, op: {:?}\nasset: {:?}\nvalue: {:?}\n",
-                        hex::encode(tx),
-                        index,
-                        withdrawal.operation,
-                        withdrawal.asset,
-                        withdrawal.amount,
-                    );
-                }
-            }
-        }
         find_lock_outputs_for_corresponding_partial_withdrawals(
             &mut projected_nft_outputs,
             &mut partial_withdrawals_inputs,
@@ -634,25 +607,6 @@ fn extract_operation_and_datum(
             for_how_long,
         } => {
             let out_ref_tx_id = out_ref.tx_id.to_raw_bytes().to_vec();
-            tracing::info!(
-                "Unlocking tx: {}@{}",
-                hex::encode(out_ref_tx_id.clone()),
-                out_ref.index
-            );
-            for (tx, withdrawal) in partial_withdrawals.iter() {
-                for (index, withdrawal) in withdrawal.iter() {
-                    for withdrawal in withdrawal.iter() {
-                        tracing::info!(
-                        "current projected nft withdrawal: tx: {:?}@{:?}, op: {:?}\nasset: {:?}\nvalue: {:?}\n",
-                        hex::encode(tx),
-                        index,
-                        withdrawal.operation,
-                        withdrawal.asset,
-                        withdrawal.amount,
-                    );
-                    }
-                }
-            }
             let partial_withdrawn_from =
                 partial_withdrawals.get(&out_ref_tx_id).and_then(|inner| {
                     if inner.contains_key(&(out_ref.index as i64)) {

--- a/indexer/tasks/src/multiera/multiera_projected_nft.rs
+++ b/indexer/tasks/src/multiera/multiera_projected_nft.rs
@@ -114,7 +114,7 @@ async fn handle_projected_nft(
     multiera_used_inputs_to_outputs_map: &BTreeMap<Vec<u8>, BTreeMap<i64, OutputWithTxData>>,
     address: String,
 ) -> Result<(), DbErr> {
-    let config_payment_cred = get_payment_cred(address)?;
+    let projected_nft_contract_payment_cred = get_payment_cred(address)?;
 
     // spent projected nfts in current transaction
     let used_projected_nfts =
@@ -123,12 +123,15 @@ async fn handle_projected_nft(
     let mut queued_projected_nft_records = vec![];
 
     for (tx_body, cardano_transaction) in block.1.txs().iter().zip(multiera_txs) {
+        // redeemers are needed to identify whil of the projected nfts are partial withdrawals
         let redeemers = tx_body
             .redeemers()
             .map(get_projected_nft_redeemers)
             .unwrap_or(Ok(BTreeMap::new()))?;
 
-        let mut partial_withdrawals = handle_claims_and_partial_withdraws(
+        // partial withdrawals inputs -- inputs which have partial withdraw = true in the redeemer
+        // this function also adds claims to the events list
+        let mut partial_withdrawals_inputs = handle_claims_and_partial_withdraws(
             tx_body,
             cardano_transaction,
             &redeemers,
@@ -136,22 +139,26 @@ async fn handle_projected_nft(
             &mut queued_projected_nft_records,
         );
 
+        // outputs with asset data and stuff
         let outputs_map = get_output_index_to_outputs_map(cardano_transaction, multiera_outputs);
 
+        // outputs that are related to projected nfts: might be locks / unlocks
         let mut projected_nft_outputs = Vec::<ProjectedNftData>::new();
 
         for (output_index, output) in tx_body.outputs().iter().enumerate() {
-            let address = output
+            let output_address = output
                 .address()
                 .map_err(|err| DbErr::Custom(format!("invalid pallas address: {}", err)))?
                 .to_hex();
 
-            let output_payment_cred = get_payment_cred(address)?;
+            let output_payment_cred = get_payment_cred(output_address)?;
 
-            if output_payment_cred != config_payment_cred {
+            if output_payment_cred != projected_nft_contract_payment_cred {
+                // the output doesn't relate to projected nft contract -> we don't care about it
                 continue;
             }
 
+            // current output details
             let output_model = outputs_map
                 .get(&(output_index as i32))
                 .ok_or(DbErr::RecordNotFound(format!(
@@ -160,135 +167,40 @@ async fn handle_projected_nft(
                 )))?
                 .clone();
 
+            // parse the state and fetch projected nft details
             let projected_nft_data =
-                extract_operation_and_datum(output, output_model, &partial_withdrawals);
-            //
-            // let entities = output.non_ada_assets().iter().map(|asset| entity::projected_nft::ActiveModel {
-            //     owner_address: Set(projected_nft_data.address.clone()),
-            //     previous_utxo_tx_output_index: Set(
-            //         projected_nft_data.previous_utxo_tx_output_index
-            //     ),
-            //     previous_utxo_tx_hash: Set(projected_nft_data.previous_utxo_tx_hash.clone()),
-            //     hololocker_utxo_id: Set(Some(output_model.id)),
-            //     tx_id: Set(cardano_transaction.id),
-            //     asset: Set(asset.subject()),
-            //     amount: Set(match asset {
-            //         Asset::Ada(value) => value as i64,
-            //         Asset::NativeAsset(_, _, value) => value as i64,
-            //     }),
-            //     operation: Set(projected_nft_data.operation.into()),
-            //     plutus_datum: Set(projected_nft_data.plutus_data.clone()),
-            //     for_how_long: Set(projected_nft_data.for_how_long),
-            //     ..Default::default()
-            // }).collect::<Vec<entity::projected_nft::ActiveModel>>();
+                extract_operation_and_datum(output, output_model, &partial_withdrawals_inputs);
 
-            if let Some((hash, index)) = &projected_nft_data.partial_withdrawn_from {
-                // get associated projected nft input
-                let partial_withdrawal_input = partial_withdrawals
-                    .get_mut(&hash.clone())
-                    .ok_or(DbErr::Custom(format!(
-                        "projected nft input hash {} should always exist",
-                        hex::encode(hash.clone())
-                    )))?
-                    .get_mut(index)
-                    .ok_or(DbErr::Custom(format!(
-                        "projected nft input with hash {} and index {} should always exist",
-                        hex::encode(hash.clone()),
-                        index
-                    )))?;
+            // if projected nft data is unlocking output that is created via partial withdrawal
+            // then we reduce associated partial withdrawal input balance by the amounts that are being unlocked
+            // this way we will be able to find the corresponding lock output that will have the rest of the balance
+            handle_partial_withdraw(&projected_nft_data, &mut partial_withdrawals_inputs)?;
 
-                // make a balance map
-                let mut asset_to_value =
-                    HashMap::<String, ProjectedNftInputsQueryOutputResult>::new();
-                for entry in partial_withdrawal_input.iter() {
-                    asset_to_value.insert(entry.asset.clone(), entry.clone());
-                }
-
-                // subtract all the assets
-                for (asset_name, asset_value) in projected_nft_data.non_ada_assets.iter() {
-                    asset_to_value
-                        .get_mut(&asset_name.clone())
-                        .ok_or(DbErr::Custom(format!(
-                            "Expected to see asset {asset_name} in projected nft {}@{index}",
-                            hex::encode(hash.clone())
-                        )))?
-                        .amount -= asset_value;
-                }
-
-                *partial_withdrawal_input = asset_to_value
-                    .values()
-                    .filter(|nft| nft.amount > 0)
-                    .cloned()
-                    .collect::<Vec<ProjectedNftInputsQueryOutputResult>>();
-
-                projected_nft_outputs.push(projected_nft_data);
-            } else {
-                projected_nft_outputs.push(projected_nft_data);
-            }
+            projected_nft_outputs.push(projected_nft_data);
         }
 
-        for nft_data in projected_nft_outputs.iter_mut() {
-            if nft_data.partial_withdrawn_from.is_some() {
-                continue;
-            }
-            let mut nft_data_assets = nft_data.non_ada_assets.clone();
-            nft_data_assets.sort_by_key(|(name, _)| name.clone());
-            let mut should_remove: Option<(Vec<u8>, i64)> = None;
+        find_lock_outputs_for_corresponding_partial_withdrawals(
+            &mut projected_nft_outputs,
+            &mut partial_withdrawals_inputs,
+        )?;
 
-            for (hash, withdrawal) in partial_withdrawals.iter() {
-                for (index, withdrawal) in withdrawal.iter() {
-                    let withdrawal_pnft = withdrawal.first().ok_or(DbErr::Custom(format!(
-                        "Expected to see an asset in utxo {}@{index}",
-                        hex::encode(hash.clone())
-                    )))?;
-                    if withdrawal_pnft.plutus_datum != nft_data.plutus_data
-                        || withdrawal_pnft.owner_address != nft_data.address
-                    {
-                        continue;
-                    }
-                    let mut withdrawal_assets = withdrawal
-                        .iter()
-                        .map(|w| (w.asset.clone(), w.amount))
-                        .collect::<Vec<_>>();
-                    withdrawal_assets.sort_by_key(|(name, _)| name.clone());
-                    if withdrawal_assets == nft_data_assets {
-                        should_remove = Some((hash.clone(), *index));
-                        nft_data.previous_utxo_tx_hash = hash.clone();
-                        nft_data.previous_utxo_tx_output_index = Some(*index);
-                        break;
-                    }
-                }
-            }
-            if let Some((hash, index)) = should_remove {
-                partial_withdrawals
-                    .get_mut(&hash)
-                    .ok_or(DbErr::Custom(format!(
-                        "hash {} should be in partial withdrawals"
-                    , hex::encode(hash.clone()))))?
-                    .remove(&index);
-                if partial_withdrawals.get_mut(&hash).unwrap().is_empty() {
-                    partial_withdrawals.remove(&hash);
-                }
-            }
+        if !partial_withdrawals_inputs.is_empty() {
+            return Err(DbErr::Custom(format!("Partial withdrawals must be empty at the end of projected nft processing, while contains: {}", partial_withdrawals_inputs.keys().map(hex::encode).fold(String::new(), |acc, key| format!("{acc},{key}")))));
         }
 
-        if !partial_withdrawals.is_empty() {
-            return Err(DbErr::Custom(format!("Partial withdrawals must be empty at the end of projected nft processing, while contains: {}", partial_withdrawals.keys().map(hex::encode).fold(String::new(), |acc, key| format!("{acc},{key}")))));
-        }
-
-        for nft_data in projected_nft_outputs.into_iter() {
-            for (asset_name, asset_value) in nft_data.non_ada_assets.into_iter() {
+        for output_data in projected_nft_outputs.into_iter() {
+            for (asset_name, asset_value) in output_data.non_ada_assets.into_iter() {
                 queued_projected_nft_records.push(entity::projected_nft::ActiveModel {
-                    owner_address: Set(nft_data.address.clone()),
-                    previous_utxo_tx_output_index: Set(nft_data.previous_utxo_tx_output_index),
-                    previous_utxo_tx_hash: Set(nft_data.previous_utxo_tx_hash.clone()),
-                    hololocker_utxo_id: Set(Some(nft_data.hololocker_utxo_id)),
+                    owner_address: Set(output_data.address.clone()),
+                    previous_utxo_tx_output_index: Set(output_data.previous_utxo_tx_output_index),
+                    previous_utxo_tx_hash: Set(output_data.previous_utxo_tx_hash.clone()),
+                    hololocker_utxo_id: Set(Some(output_data.hololocker_utxo_id)),
                     tx_id: Set(cardano_transaction.id),
                     asset: Set(asset_name),
                     amount: Set(asset_value),
-                    operation: Set(nft_data.operation.into()),
-                    plutus_datum: Set(nft_data.plutus_data.clone()),
-                    for_how_long: Set(nft_data.for_how_long),
+                    operation: Set(output_data.operation.into()),
+                    plutus_datum: Set(output_data.plutus_data.clone()),
+                    for_how_long: Set(output_data.for_how_long),
                     ..Default::default()
                 });
             }
@@ -300,6 +212,122 @@ async fn handle_projected_nft(
             .exec(db_tx)
             .await?;
     }
+
+    Ok(())
+}
+
+fn find_lock_outputs_for_corresponding_partial_withdrawals(
+    projected_nft_outputs: &mut [ProjectedNftData],
+    partial_withdrawals_inputs: &mut BTreeMap<
+        Vec<u8>,
+        BTreeMap<i64, Vec<ProjectedNftInputsQueryOutputResult>>,
+    >,
+) -> Result<(), DbErr> {
+    for output_data in projected_nft_outputs.iter_mut() {
+        if output_data.partial_withdrawn_from_input.is_some() {
+            continue;
+        }
+
+        let mut nft_data_assets = output_data.non_ada_assets.clone();
+        nft_data_assets.sort_by_key(|(name, _)| name.clone());
+
+        let mut withdrawal_input_to_remove: Option<(Vec<u8>, i64)> = None;
+
+        for (input_hash, withdrawal) in partial_withdrawals_inputs.iter() {
+            for (input_index, withdrawal) in withdrawal.iter() {
+                let withdrawal_data = withdrawal.first().ok_or(DbErr::Custom(format!(
+                    "Expected to see an asset in utxo {}@{input_index}",
+                    hex::encode(input_hash.clone())
+                )))?;
+                if withdrawal_data.plutus_datum != output_data.plutus_data
+                    || withdrawal_data.owner_address != output_data.address
+                {
+                    continue;
+                }
+
+                let mut withdrawal_assets = withdrawal
+                    .iter()
+                    .map(|w| (w.asset.clone(), w.amount))
+                    .collect::<Vec<_>>();
+                withdrawal_assets.sort_by_key(|(name, _)| name.clone());
+
+                if withdrawal_assets == nft_data_assets {
+                    withdrawal_input_to_remove = Some((input_hash.clone(), *input_index));
+                    output_data.previous_utxo_tx_hash = input_hash.clone();
+                    output_data.previous_utxo_tx_output_index = Some(*input_index);
+                    break;
+                }
+            }
+        }
+
+        if let Some((hash, index)) = withdrawal_input_to_remove {
+            partial_withdrawals_inputs
+                .get_mut(&hash)
+                .unwrap()
+                .remove(&index);
+            if partial_withdrawals_inputs
+                .get_mut(&hash)
+                .unwrap()
+                .is_empty()
+            {
+                partial_withdrawals_inputs.remove(&hash);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn handle_partial_withdraw(
+    output_projected_nft_data: &ProjectedNftData,
+    partial_withdrawals_inputs: &mut BTreeMap<
+        Vec<u8>,
+        BTreeMap<i64, Vec<ProjectedNftInputsQueryOutputResult>>,
+    >,
+) -> Result<(), DbErr> {
+    let (withdrawn_from_input_hash, withdrawn_from_input_index) =
+        if let Some((hash, index)) = &output_projected_nft_data.partial_withdrawn_from_input {
+            (hash, index)
+        } else {
+            return Ok(());
+        };
+
+    // get associated projected nft input
+    let partial_withdrawal_input = partial_withdrawals_inputs
+        .get_mut(&withdrawn_from_input_hash.clone())
+        .ok_or(DbErr::Custom(format!(
+            "projected nft input hash {} should always exist",
+            hex::encode(withdrawn_from_input_hash.clone())
+        )))?
+        .get_mut(withdrawn_from_input_index)
+        .ok_or(DbErr::Custom(format!(
+            "projected nft input with hash {} and index {} should always exist",
+            hex::encode(withdrawn_from_input_hash.clone()),
+            withdrawn_from_input_index
+        )))?;
+
+    // make a balance map
+    let mut input_asset_to_value = HashMap::<String, ProjectedNftInputsQueryOutputResult>::new();
+    for entry in partial_withdrawal_input.iter() {
+        input_asset_to_value.insert(entry.asset.clone(), entry.clone());
+    }
+
+    // subtract all the assets
+    for (output_asset_name, output_asset_value) in output_projected_nft_data.non_ada_assets.iter() {
+        input_asset_to_value
+            .get_mut(&output_asset_name.clone())
+            .ok_or(DbErr::Custom(format!(
+                "Expected to see asset {output_asset_name} in projected nft {}@{withdrawn_from_input_index}",
+                hex::encode(withdrawn_from_input_hash.clone())
+            )))?
+            .amount -= output_asset_value;
+    }
+
+    *partial_withdrawal_input = input_asset_to_value
+        .values()
+        .filter(|nft| nft.amount > 0)
+        .cloned()
+        .collect::<Vec<ProjectedNftInputsQueryOutputResult>>();
 
     Ok(())
 }
@@ -474,7 +502,8 @@ struct ProjectedNftData {
     pub plutus_data: Vec<u8>,
     pub operation: ProjectedNftOperation,
     pub for_how_long: Option<i64>,
-    pub partial_withdrawn_from: Option<(Vec<u8>, i64)>,
+    // this field is set only on unlocking outputs that were created through partial withdraw
+    pub partial_withdrawn_from_input: Option<(Vec<u8>, i64)>,
     pub non_ada_assets: Vec<(String, i64)>,
     pub hololocker_utxo_id: i64,
 }
@@ -581,7 +610,7 @@ fn extract_operation_and_datum(
                 operation: ProjectedNftOperation::Unlocking,
                 for_how_long: Some(for_how_long as i64),
                 hololocker_utxo_id: output_model.id,
-                partial_withdrawn_from,
+                partial_withdrawn_from_input: partial_withdrawn_from,
                 non_ada_assets,
             }
         }

--- a/indexer/tasks/src/multiera/multiera_projected_nft.rs
+++ b/indexer/tasks/src/multiera/multiera_projected_nft.rs
@@ -1,7 +1,11 @@
 use anyhow::anyhow;
-use cml_chain::transaction::TransactionBody;
-use cml_core::serialization::{FromBytes, Serialize};
+use cardano_multiplatform_lib::error::DeserializeError;
+use cml_core::serialization::FromBytes;
 use cml_crypto::RawBytesEncoding;
+use pallas::ledger::primitives::alonzo::{Redeemer, RedeemerTag};
+use pallas::ledger::primitives::babbage::DatumOption;
+use pallas::ledger::primitives::Fragment;
+use pallas::ledger::traverse::{Asset, MultiEraOutput, MultiEraTx};
 use projected_nft_sdk::{Owner, Redeem, State, Status};
 use sea_orm::{FromQueryResult, JoinType, QuerySelect, QueryTrait};
 use std::collections::{BTreeSet, HashMap, HashSet};
@@ -118,21 +122,17 @@ async fn handle_projected_nft(
 
     let mut queued_projected_nft_records = vec![];
 
-    for (parsed_tx, cardano_transaction) in block.1.txs().iter().zip(multiera_txs) {
-        let parsed_tx = cml_chain::transaction::Transaction::from_bytes(parsed_tx.encode())
-            .map_err(|err| DbErr::Custom(format!("Can't parse tx body: {err}")))?;
-
+    for (tx_body, cardano_transaction) in block.1.txs().iter().zip(multiera_txs) {
         // redeemers are needed to identify whil of the projected nfts are partial withdrawals
-        let redeemers = parsed_tx
-            .witness_set
-            .redeemers
+        let redeemers = tx_body
+            .redeemers()
             .map(get_projected_nft_redeemers)
             .unwrap_or(Ok(BTreeMap::new()))?;
 
         // partial withdrawals inputs -- inputs which have partial withdraw = true in the redeemer
         // this function also adds claims to the events list
         let mut partial_withdrawals_inputs = handle_claims_and_partial_withdraws(
-            &parsed_tx.body,
+            tx_body,
             cardano_transaction,
             &redeemers,
             &used_projected_nfts,
@@ -145,10 +145,18 @@ async fn handle_projected_nft(
         // outputs that are related to projected nfts: might be locks / unlocks
         let mut projected_nft_outputs = Vec::<ProjectedNftData>::new();
 
-        for (output_index, output) in parsed_tx.body.outputs.iter().enumerate() {
-            let output_payment_cred = match output.address().payment_cred() {
+        for (output_index, output) in tx_body.outputs().iter().enumerate() {
+            let output_address = output
+                .address()
+                .map_err(|err| DbErr::Custom(format!("invalid pallas address: {}", err)))?
+                .to_vec();
+
+            let output_address =
+                cardano_multiplatform_lib::address::Address::from_bytes(output_address)
+                    .map_err(|err| DbErr::Custom(format!("cml can't parse address: {}", err)))?;
+            let output_payment_cred = match output_address.payment_cred() {
                 None => continue,
-                Some(pk) => pk.clone(),
+                Some(pk) => pk,
             };
 
             if output_payment_cred != projected_nft_contract_payment_cred {
@@ -175,35 +183,6 @@ async fn handle_projected_nft(
             handle_partial_withdraw(&projected_nft_data, &mut partial_withdrawals_inputs)?;
 
             projected_nft_outputs.push(projected_nft_data);
-        }
-
-        for projected_nft_output in projected_nft_outputs.iter() {
-            for (asset_name, asset_value) in projected_nft_output.non_ada_assets.iter() {
-                tracing::info!(
-                    "projected nft output: op: {:?}, partial: {}\nasset: {:?}\nvalue: {:?}\nprev tx: {:?}@{:?}",
-                    projected_nft_output.operation,
-                    projected_nft_output.partial_withdrawn_from_input.is_some(),
-                    asset_name,
-                    asset_value,
-                    hex::encode(projected_nft_output.previous_utxo_tx_hash.clone()),
-                    projected_nft_output.previous_utxo_tx_output_index,
-                );
-            }
-        }
-
-        for (tx, withdrawal) in partial_withdrawals_inputs.iter() {
-            for (index, withdrawal) in withdrawal.iter() {
-                for withdrawal in withdrawal.iter() {
-                    tracing::info!(
-                        "projected nft withdrawal: tx: {:?}@{:?}, op: {:?}\nasset: {:?}\nvalue: {:?}\n",
-                        hex::encode(tx),
-                        index,
-                        withdrawal.operation,
-                        withdrawal.asset,
-                        withdrawal.amount,
-                    );
-                }
-            }
         }
 
         find_lock_outputs_for_corresponding_partial_withdrawals(
@@ -359,7 +338,9 @@ fn handle_partial_withdraw(
     Ok(())
 }
 
-fn get_payment_cred(address: String) -> Result<cml_chain::certs::StakeCredential, DbErr> {
+fn get_payment_cred(
+    address: String,
+) -> Result<cardano_multiplatform_lib::address::StakeCredential, DbErr> {
     let config_address = hex::decode(address).map_err(|err| {
         DbErr::Custom(format!(
             "can't decode projected nft config address hex: {:?}",
@@ -367,13 +348,13 @@ fn get_payment_cred(address: String) -> Result<cml_chain::certs::StakeCredential
         ))
     })?;
 
-    let config_address = cml_chain::address::Address::from_bytes(config_address)
+    let config_address = cardano_multiplatform_lib::address::Address::from_bytes(config_address)
         .map_err(|err| DbErr::Custom(format!("cml can't parse config address: {:?}", err)))?;
     match config_address.payment_cred() {
         None => Err(DbErr::Custom(
             "provided projected nft config address contains no payment cred".to_string(),
         )),
-        Some(pk) => Ok(pk.clone()),
+        Some(pk) => Ok(pk),
     }
 }
 
@@ -431,7 +412,7 @@ async fn get_projected_nft_inputs(
 }
 
 fn handle_claims_and_partial_withdraws(
-    tx_body: &TransactionBody,
+    tx_body: &MultiEraTx,
     cardano_transaction: &TransactionModel,
     redeemers: &BTreeMap<i64, Redeem>,
     used_projected_nfts: &BTreeMap<
@@ -442,20 +423,14 @@ fn handle_claims_and_partial_withdraws(
 ) -> BTreeMap<Vec<u8>, BTreeMap<i64, Vec<ProjectedNftInputsQueryOutputResult>>> {
     let mut partially_withdrawn = BTreeMap::new();
 
-    for (input_index, input) in tx_body.inputs.iter().enumerate() {
-        let input_tx_id = input.transaction_id.to_raw_bytes().to_vec();
-        tracing::info!(
-            "input #{input_index}: {}@{}",
-            hex::encode(&input_tx_id),
-            input.index
-        );
-        let entry = if let Some(entry) = used_projected_nfts.get(&input_tx_id) {
+    for (input_index, input) in tx_body.inputs().iter().enumerate() {
+        let entry = if let Some(entry) = used_projected_nfts.get(&input.hash().to_vec()) {
             entry
         } else {
             continue;
         };
 
-        let projected_nfts = if let Some(projected_nfts) = entry.get(&(input.index as i64)) {
+        let projected_nfts = if let Some(projected_nfts) = entry.get(&(input.index() as i64)) {
             projected_nfts
         } else {
             continue;
@@ -500,7 +475,7 @@ fn handle_claims_and_partial_withdraws(
 
         if !current_input_partial_withrawal.is_empty() {
             *partially_withdrawn
-                .entry(input_tx_id)
+                .entry(input.hash().to_vec())
                 .or_insert(BTreeMap::new())
                 .entry(input_index as i64)
                 .or_default() = current_input_partial_withrawal;
@@ -540,7 +515,7 @@ struct ProjectedNftData {
 }
 
 fn extract_operation_and_datum(
-    output: &cml_chain::transaction::TransactionOutput,
+    output: &MultiEraOutput,
     output_model: entity::transaction_output::Model,
     partial_withdrawals: &BTreeMap<
         Vec<u8>,
@@ -548,7 +523,7 @@ fn extract_operation_and_datum(
     >,
 ) -> ProjectedNftData {
     let datum_option = match output.datum() {
-        Some(datum) => datum,
+        Some(datum) => DatumOption::from(datum.clone()),
         None => {
             return ProjectedNftData {
                 operation: ProjectedNftOperation::NoDatum,
@@ -558,22 +533,33 @@ fn extract_operation_and_datum(
     };
 
     let datum = match datum_option {
-        cml_chain::transaction::DatumOption::Hash { datum_hash, .. } => {
+        DatumOption::Hash(hash) => {
             return ProjectedNftData {
-                plutus_data: datum_hash.to_raw_bytes().to_vec(),
+                plutus_data: hash.to_vec(),
                 // the contract expects inline datums only
                 operation: ProjectedNftOperation::NotInlineDatum,
                 ..Default::default()
             };
         }
-        cml_chain::transaction::DatumOption::Datum { datum, .. } => datum,
+        DatumOption::Data(datum) => datum.0.encode_fragment().unwrap(),
     };
 
-    let parsed = match projected_nft_sdk::State::try_from(datum.clone()) {
+    let parsed = match cml_chain::plutus::PlutusData::from_bytes(datum.clone()) {
         Ok(parsed) => parsed,
         Err(_) => {
             return ProjectedNftData {
-                plutus_data: datum.to_cbor_bytes(),
+                plutus_data: datum,
+                operation: ProjectedNftOperation::ParseError,
+                ..Default::default()
+            }
+        }
+    };
+
+    let parsed = match projected_nft_sdk::State::try_from(parsed) {
+        Ok(parsed) => parsed,
+        Err(_) => {
+            return ProjectedNftData {
+                plutus_data: datum,
                 operation: ProjectedNftOperation::ParseError,
                 ..Default::default()
             }
@@ -587,27 +573,22 @@ fn extract_operation_and_datum(
     };
 
     let non_ada_assets = output
-        .amount()
-        .multiasset
+        .non_ada_assets()
         .iter()
-        .flat_map(|(policy_id, asset_names)| {
-            asset_names.iter().map(|(asset_name, coin)| {
-                (
-                    format!(
-                        "{}.{}",
-                        policy_id.to_hex(),
-                        hex::encode(asset_name.to_cbor_bytes())
-                    ),
-                    *coin as i64,
-                )
-            })
+        .map(|asset| {
+            (
+                asset.subject(),
+                match asset {
+                    Asset::Ada(value) => *value as i64,
+                    Asset::NativeAsset(_, _, value) => *value as i64,
+                },
+            )
         })
         .collect::<Vec<(String, i64)>>();
-
     match parsed.status {
         Status::Locked => ProjectedNftData {
             address: owner_address,
-            plutus_data: datum.to_cbor_bytes(),
+            plutus_data: datum,
             operation: ProjectedNftOperation::Lock,
             hololocker_utxo_id: output_model.id,
             non_ada_assets,
@@ -631,7 +612,7 @@ fn extract_operation_and_datum(
                 previous_utxo_tx_hash: out_ref.tx_id.to_raw_bytes().to_vec(),
                 previous_utxo_tx_output_index: Some(out_ref.index as i64),
                 address: owner_address,
-                plutus_data: datum.to_cbor_bytes(),
+                plutus_data: datum,
                 operation: ProjectedNftOperation::Unlocking,
                 for_how_long: Some(for_how_long as i64),
                 hololocker_utxo_id: output_model.id,
@@ -642,17 +623,19 @@ fn extract_operation_and_datum(
     }
 }
 
-fn get_projected_nft_redeemers(
-    redeemers: Vec<cml_chain::plutus::Redeemer>,
-) -> Result<BTreeMap<i64, Redeem>, DbErr> {
+fn get_projected_nft_redeemers(redeemers: &[Redeemer]) -> Result<BTreeMap<i64, Redeem>, DbErr> {
     let mut result = BTreeMap::new();
 
     for redeemer in redeemers {
-        if redeemer.tag != cml_chain::plutus::RedeemerTag::Spend {
+        if redeemer.tag != RedeemerTag::Spend {
             continue;
         }
 
-        match Redeem::try_from(redeemer.data.clone()) {
+        let plutus_data = redeemer.data.encode_fragment().unwrap();
+        let plutus_data = cml_chain::plutus::PlutusData::from_bytes(plutus_data)
+            .map_err(|err| DbErr::Custom(format!("Can't parse plutus data: {err}")))?;
+
+        match Redeem::try_from(plutus_data) {
             Ok(redeem) => {
                 result.insert(redeemer.index as i64, redeem);
             }

--- a/indexer/tasks/src/multiera/multiera_projected_nft.rs
+++ b/indexer/tasks/src/multiera/multiera_projected_nft.rs
@@ -512,7 +512,7 @@ fn handle_claims_and_partial_withdraws(
             *partially_withdrawn
                 .entry(input.hash().to_vec())
                 .or_insert(BTreeMap::new())
-                .entry(input_index as i64)
+                .entry(input.index() as i64)
                 .or_default() = current_input_partial_withrawal;
         }
     }

--- a/indexer/tasks/src/multiera/utils/cip25_parse.rs
+++ b/indexer/tasks/src/multiera/utils/cip25_parse.rs
@@ -23,8 +23,8 @@ fn is_policy_key(key: &Metadatum) -> Option<PolicyId> {
 // There's probably a much more formal approach.
 fn is_asset_key(key: &Metadatum) -> Option<AssetName> {
     match key {
-        Metadatum::Bytes(x) if x.len() <= 32 => AssetName::try_from(x.as_slice()).ok(),
-        Metadatum::Text(x) if x.as_bytes().len() <= 32 => AssetName::try_from(x.as_bytes()).ok(),
+        Metadatum::Bytes(x) if x.len() <= 32 => Some(AssetName::from(x.as_slice())),
+        Metadatum::Text(x) if x.as_bytes().len() <= 32 => Some(AssetName::from(x.as_bytes())),
         _ => None,
     }
 }

--- a/webserver/server/app/controllers/ProjectedNftRangeController.ts
+++ b/webserver/server/app/controllers/ProjectedNftRangeController.ts
@@ -38,11 +38,11 @@ export class ProjectedNftRangeController extends Controller {
                 actionTxId: data.action_tx_id,
                 actionOutputIndex: data.action_output_index,
                 asset: data.asset,
-                amount: BigInt(data.amount),
+                amount: data.amount,
                 status: data.status,
                 plutusDatum: data.plutus_datum,
                 actionSlot: data.action_slot,
-                forHowLong: data.for_how_long != null ? BigInt(data.for_how_long) : null,
+                forHowLong: data.for_how_long,
             }));
         });
 

--- a/webserver/server/app/controllers/ProjectedNftRangeController.ts
+++ b/webserver/server/app/controllers/ProjectedNftRangeController.ts
@@ -38,11 +38,11 @@ export class ProjectedNftRangeController extends Controller {
                 actionTxId: data.action_tx_id,
                 actionOutputIndex: data.action_output_index,
                 asset: data.asset,
-                amount: parseInt(data.amount),
+                amount: BigInt(data.amount),
                 status: data.status,
                 plutusDatum: data.plutus_datum,
                 actionSlot: data.action_slot,
-                forHowLong: data.for_how_long != null ? parseInt(data.for_how_long) : null,
+                forHowLong: data.for_how_long != null ? BigInt(data.for_how_long) : null,
             }));
         });
 

--- a/webserver/shared/models/ProjectedNftRange.ts
+++ b/webserver/shared/models/ProjectedNftRange.ts
@@ -75,9 +75,9 @@ export type ProjectedNftRangeResponse = {
     /**
      * Number of assets of `asset` type used in this Projected NFT event.
      *
-     * @example 1
+     * @example "1"
      */
-    amount: bigint,
+    amount: string,
     /**
      * Projected NFT status: Lock / Unlocking / Claim / Invalid
      *
@@ -95,7 +95,7 @@ export type ProjectedNftRangeResponse = {
      * UNIX timestamp till which the funds can't be claimed in the Unlocking state.
      * If the status is not Unlocking this is always null.
      *
-     * @example 1701266986000
+     * @example "1701266986000"
      */
-    forHowLong: bigint | null,
+    forHowLong: string | null,
 }[];

--- a/webserver/shared/models/ProjectedNftRange.ts
+++ b/webserver/shared/models/ProjectedNftRange.ts
@@ -77,7 +77,7 @@ export type ProjectedNftRangeResponse = {
      *
      * @example 1
      */
-    amount: number,
+    amount: bigint,
     /**
      * Projected NFT status: Lock / Unlocking / Claim / Invalid
      *
@@ -97,5 +97,5 @@ export type ProjectedNftRangeResponse = {
      *
      * @example 1701266986000
      */
-    forHowLong: number | null,
+    forHowLong: bigint | null,
 }[];


### PR DESCRIPTION
While adding paima funnel 2 bugs were found:
* if claimed projected nft had more than 1 asset then only first one was saved as event
* if a locked asset is locked based on partial withdrawal, previous lock wasn't linked to the new one. so it was impossible to identify which lock created a new one and update the state. in this pr partial withdrawals are linked with subsequent locks