### PR TITLE
utxos by asset add policy id filtering

### DIFF
--- a/docs/bin/openapi.json
+++ b/docs/bin/openapi.json
@@ -146,6 +146,11 @@
                 ],
                 "type": "object"
             },
+            "AssetName": {
+                "type": "string",
+                "example": "42657272794e617679",
+                "pattern": "[0-9a-fA-F]{0,64}"
+            },
             "AssetUtxosResponse": {
                 "items": {
                     "properties": {
@@ -157,6 +162,15 @@
                             "format": "double"
                         },
                         "paymentCred": {
+                            "type": "string"
+                        },
+                        "assetName": {
+                            "$ref": "#/components/schemas/AssetName"
+                        },
+                        "policyId": {
+                            "type": "string"
+                        },
+                        "cip14Fingerprint": {
                             "type": "string"
                         },
                         "utxo": {
@@ -176,16 +190,17 @@
                             "type": "object"
                         },
                         "amount": {
-                            "type": "number",
-                            "format": "double",
-                            "description": "If the utxo is created, this has the amount. It's undefined if the utxo\nis spent.",
-                            "example": 1031423725351
+                            "type": "string",
+                            "description": "If the utxo is created, this has the amount. It's undefined if the utxo\nis spent."
                         }
                     },
                     "required": [
                         "txId",
                         "slot",
                         "paymentCred",
+                        "assetName",
+                        "policyId",
+                        "cip14Fingerprint",
                         "utxo"
                     ],
                     "type": "object"
@@ -196,9 +211,20 @@
                 "type": "string",
                 "example": "asset1c43p68zwjezc7f6w4w9qkhkwv9ppwz0f7c3amw"
             },
+            "PolicyId": {
+                "type": "string",
+                "example": "b863bc7369f46136ac1048adb2fa7dae3af944c3bbb2be2f216a8d4f",
+                "pattern": "[0-9a-fA-F]{56}"
+            },
             "AssetUtxosRequest": {
                 "properties": {
-                    "assets": {
+                    "policyIds": {
+                        "items": {
+                            "$ref": "#/components/schemas/PolicyId"
+                        },
+                        "type": "array"
+                    },
+                    "fingerprints": {
                         "items": {
                             "$ref": "#/components/schemas/Cip14Fingerprint"
                         },
@@ -223,7 +249,6 @@
                     }
                 },
                 "required": [
-                    "assets",
                     "range"
                 ],
                 "type": "object"
@@ -477,16 +502,6 @@
                     "pools"
                 ],
                 "type": "object"
-            },
-            "PolicyId": {
-                "type": "string",
-                "example": "b863bc7369f46136ac1048adb2fa7dae3af944c3bbb2be2f216a8d4f",
-                "pattern": "[0-9a-fA-F]{56}"
-            },
-            "AssetName": {
-                "type": "string",
-                "example": "42657272794e617679",
-                "pattern": "[0-9a-fA-F]{0,64}"
             },
             "Asset": {
                 "properties": {

--- a/indexer/tasks/src/multiera/multiera_asset_utxo.rs
+++ b/indexer/tasks/src/multiera/multiera_asset_utxo.rs
@@ -1,6 +1,6 @@
 use super::multiera_stake_credentials::MultieraStakeCredentialTask;
-use crate::config::AddressConfig::PayloadAndReadonlyConfig;
 use crate::config::EmptyConfig::EmptyConfig;
+use crate::config::PayloadAndReadonlyConfig;
 use crate::config::ReadonlyConfig::ReadonlyConfig;
 use crate::dsl::task_macro::*;
 use crate::multiera::dex::common::filter_outputs_and_datums_by_address;

--- a/webserver/server/app/models/asset/assetUtxos.queries.ts
+++ b/webserver/server/app/models/asset/assetUtxos.queries.ts
@@ -3,18 +3,21 @@ import { PreparedQuery } from '@pgtyped/query';
 
 /** 'AssetUtxos' parameters type */
 export interface IAssetUtxosParams {
-  fingerprints: readonly (Buffer)[];
+  fingerprints: readonly (Buffer | null | void)[];
   max_slot: number;
   min_slot: number;
+  policyIds: readonly (Buffer | null | void)[];
 }
 
 /** 'AssetUtxos' return type */
 export interface IAssetUtxosResult {
   address_raw: Buffer;
   amount: string | null;
+  asset_name: Buffer;
   cip14_fingerprint: Buffer;
   output_index: number;
   output_tx_hash: string | null;
+  policy_id: Buffer;
   slot: number;
   tx_hash: string | null;
 }
@@ -25,7 +28,7 @@ export interface IAssetUtxosQuery {
   result: IAssetUtxosResult;
 }
 
-const assetUtxosIR: any = {"usedParamSet":{"fingerprints":true,"min_slot":true,"max_slot":true},"params":[{"name":"fingerprints","required":true,"transform":{"type":"array_spread"},"locs":[{"a":677,"b":690}]},{"name":"min_slot","required":true,"transform":{"type":"scalar"},"locs":[{"a":712,"b":721}]},{"name":"max_slot","required":true,"transform":{"type":"scalar"},"locs":[{"a":744,"b":753}]}],"statement":"SELECT ENCODE(TXO.HASH,\n        'hex') OUTPUT_TX_HASH,\n    \"TransactionOutput\".OUTPUT_INDEX,\n\t\"NativeAsset\".CIP14_FINGERPRINT,\n\t\"AssetUtxo\".AMOUNT,\n\t\"Block\".SLOT,\n\tENCODE(\"Transaction\".HASH,\n        'hex') TX_HASH,\n\t\"Address\".PAYLOAD ADDRESS_RAW\nFROM \"AssetUtxo\"\nJOIN \"Transaction\" ON \"AssetUtxo\".TX_ID = \"Transaction\".ID\nJOIN \"TransactionOutput\" ON \"AssetUtxo\".UTXO_ID = \"TransactionOutput\".ID\nJOIN \"Transaction\" TXO ON \"TransactionOutput\".TX_ID = TXO.ID\nJOIN \"Address\" ON \"Address\".id = \"TransactionOutput\".address_id\nJOIN \"NativeAsset\" ON \"AssetUtxo\".ASSET_ID = \"NativeAsset\".ID\nJOIN \"Block\" ON \"Transaction\".BLOCK_ID = \"Block\".ID\nWHERE \n\t\"NativeAsset\".CIP14_FINGERPRINT IN :fingerprints! AND\n\t\"Block\".SLOT > :min_slot! AND\n\t\"Block\".SLOT <= :max_slot!\nORDER BY \"Transaction\".ID ASC"};
+const assetUtxosIR: any = {"usedParamSet":{"fingerprints":true,"policyIds":true,"min_slot":true,"max_slot":true},"params":[{"name":"fingerprints","required":false,"transform":{"type":"array_spread"},"locs":[{"a":731,"b":743}]},{"name":"policyIds","required":false,"transform":{"type":"array_spread"},"locs":[{"a":777,"b":786}]},{"name":"min_slot","required":true,"transform":{"type":"scalar"},"locs":[{"a":811,"b":820}]},{"name":"max_slot","required":true,"transform":{"type":"scalar"},"locs":[{"a":843,"b":852}]}],"statement":"SELECT ENCODE(TXO.HASH,\n        'hex') OUTPUT_TX_HASH,\n    \"TransactionOutput\".OUTPUT_INDEX,\n\t\"NativeAsset\".CIP14_FINGERPRINT,\n\t\"NativeAsset\".POLICY_ID,\n\t\"NativeAsset\".ASSET_NAME,\n\t\"AssetUtxo\".AMOUNT,\n\t\"Block\".SLOT,\n\tENCODE(\"Transaction\".HASH,\n        'hex') TX_HASH,\n\t\"Address\".PAYLOAD ADDRESS_RAW\nFROM \"AssetUtxo\"\nJOIN \"Transaction\" ON \"AssetUtxo\".TX_ID = \"Transaction\".ID\nJOIN \"TransactionOutput\" ON \"AssetUtxo\".UTXO_ID = \"TransactionOutput\".ID\nJOIN \"Transaction\" TXO ON \"TransactionOutput\".TX_ID = TXO.ID\nJOIN \"Address\" ON \"Address\".id = \"TransactionOutput\".address_id\nJOIN \"NativeAsset\" ON \"AssetUtxo\".ASSET_ID = \"NativeAsset\".ID\nJOIN \"Block\" ON \"Transaction\".BLOCK_ID = \"Block\".ID\nWHERE \n\t(\"NativeAsset\".CIP14_FINGERPRINT IN :fingerprints\n\t\tOR \"NativeAsset\".POLICY_ID IN :policyIds\n\t) AND\n\t\"Block\".SLOT > :min_slot! AND\n\t\"Block\".SLOT <= :max_slot!\nORDER BY \"Transaction\".ID, \"AssetUtxo\".ID ASC"};
 
 /**
  * Query generated from SQL:
@@ -34,6 +37,8 @@ const assetUtxosIR: any = {"usedParamSet":{"fingerprints":true,"min_slot":true,"
  *         'hex') OUTPUT_TX_HASH,
  *     "TransactionOutput".OUTPUT_INDEX,
  * 	"NativeAsset".CIP14_FINGERPRINT,
+ * 	"NativeAsset".POLICY_ID,
+ * 	"NativeAsset".ASSET_NAME,
  * 	"AssetUtxo".AMOUNT,
  * 	"Block".SLOT,
  * 	ENCODE("Transaction".HASH,
@@ -47,10 +52,12 @@ const assetUtxosIR: any = {"usedParamSet":{"fingerprints":true,"min_slot":true,"
  * JOIN "NativeAsset" ON "AssetUtxo".ASSET_ID = "NativeAsset".ID
  * JOIN "Block" ON "Transaction".BLOCK_ID = "Block".ID
  * WHERE 
- * 	"NativeAsset".CIP14_FINGERPRINT IN :fingerprints! AND
+ * 	("NativeAsset".CIP14_FINGERPRINT IN :fingerprints
+ * 		OR "NativeAsset".POLICY_ID IN :policyIds
+ * 	) AND
  * 	"Block".SLOT > :min_slot! AND
  * 	"Block".SLOT <= :max_slot!
- * ORDER BY "Transaction".ID ASC
+ * ORDER BY "Transaction".ID, "AssetUtxo".ID ASC
  * ```
  */
 export const assetUtxos = new PreparedQuery<IAssetUtxosParams,IAssetUtxosResult>(assetUtxosIR);

--- a/webserver/server/app/models/asset/assetUtxos.sql
+++ b/webserver/server/app/models/asset/assetUtxos.sql
@@ -1,11 +1,14 @@
 /* 
 @name AssetUtxos 
 @param fingerprints -> (...)
+@param policyIds -> (...)
 */
 SELECT ENCODE(TXO.HASH,
         'hex') OUTPUT_TX_HASH,
     "TransactionOutput".OUTPUT_INDEX,
 	"NativeAsset".CIP14_FINGERPRINT,
+	"NativeAsset".POLICY_ID,
+	"NativeAsset".ASSET_NAME,
 	"AssetUtxo".AMOUNT,
 	"Block".SLOT,
 	ENCODE("Transaction".HASH,
@@ -19,7 +22,9 @@ JOIN "Address" ON "Address".id = "TransactionOutput".address_id
 JOIN "NativeAsset" ON "AssetUtxo".ASSET_ID = "NativeAsset".ID
 JOIN "Block" ON "Transaction".BLOCK_ID = "Block".ID
 WHERE 
-	"NativeAsset".CIP14_FINGERPRINT IN :fingerprints! AND
+	("NativeAsset".CIP14_FINGERPRINT IN :fingerprints
+		OR "NativeAsset".POLICY_ID IN :policyIds
+	) AND
 	"Block".SLOT > :min_slot! AND
 	"Block".SLOT <= :max_slot!
 ORDER BY "Transaction".ID, "AssetUtxo".ID ASC;

--- a/webserver/server/app/services/AssetUtxos.ts
+++ b/webserver/server/app/services/AssetUtxos.ts
@@ -7,14 +7,21 @@ export async function getAssetUtxos(request: {
     minSlot: number;
     maxSlot: number;
   };
-  assets: Buffer[];
+  fingerprints?: Buffer[];
+  policyIds?: Buffer[];
   dbTx: PoolClient;
 }): Promise<IAssetUtxosResult[]> {
   return await assetUtxos.run(
     {
       max_slot: request.range.maxSlot,
       min_slot: request.range.minSlot,
-      fingerprints: request.assets,
+      // pgtyped doesn't seem to have a way to have an optional array parameter,
+      // and an empty spread expansion fails with postgres.  Since none of these
+      // fields is nullable, an array with null should be equivalent to an empty
+      // array.
+      fingerprints:
+        request.fingerprints && request.fingerprints.length > 0 ? request.fingerprints : [null],
+      policyIds: request.policyIds && request.policyIds.length > 0 ? request.policyIds : [null],
     },
     request.dbTx
   );

--- a/webserver/shared/models/AssetUtxos.ts
+++ b/webserver/shared/models/AssetUtxos.ts
@@ -5,7 +5,8 @@ export type Cip14Fingerprint = string;
 
 export type AssetUtxosRequest = {
   range: { minSlot: number; maxSlot: number },
-  assets: Cip14Fingerprint[]
+  fingerprints?: Cip14Fingerprint[],
+  policyIds?: string[]
 };
 
 export type AssetUtxosResponse = {
@@ -22,6 +23,8 @@ export type AssetUtxosResponse = {
       index: number,
     },
     cip14Fingerprint: string,
+    policyId: string,
+    assetName: string,
     paymentCred: string,
     slot: number
     txId: string,

--- a/webserver/shared/models/AssetUtxos.ts
+++ b/webserver/shared/models/AssetUtxos.ts
@@ -1,31 +1,32 @@
+import { AssetName, PolicyId } from "./PolicyIdAssetMap";
+
 /**
  * @example "asset1c43p68zwjezc7f6w4w9qkhkwv9ppwz0f7c3amw"
  */
 export type Cip14Fingerprint = string;
 
 export type AssetUtxosRequest = {
-  range: { minSlot: number; maxSlot: number },
-  fingerprints?: Cip14Fingerprint[],
-  policyIds?: string[]
+  range: { minSlot: number; maxSlot: number };
+  fingerprints?: Cip14Fingerprint[];
+  policyIds?: PolicyId[];
 };
 
 export type AssetUtxosResponse = {
-
-    /**
-     * If the utxo is created, this has the amount. It's undefined if the utxo
-     * is spent. 
-     *
-     * @example '1031423725351'
-     */
-    amount: string | undefined,
-    utxo: {
-      tx: string,
-      index: number,
-    },
-    cip14Fingerprint: string,
-    policyId: string,
-    assetName: string,
-    paymentCred: string,
-    slot: number
-    txId: string,
+  /**
+   * If the utxo is created, this has the amount. It's undefined if the utxo
+   * is spent.
+   *
+   * @example '1031423725351'
+   */
+  amount: string | undefined;
+  utxo: {
+    tx: string;
+    index: number;
+  };
+  cip14Fingerprint: string;
+  policyId: string;
+  assetName: AssetName;
+  paymentCred: string;
+  slot: number;
+  txId: string;
 }[];


### PR DESCRIPTION
With these changes any of the following are valid:

```
curl -X "POST" "http://localhost:3000/asset/utxos" \
     -H 'Content-Type: application/json; charset=utf-8' \
     -d $'{
  "fingerprints": ["asset1c43p68zwjezc7f6w4w9qkhkwv9ppwz0f7c3amw"],
  "range": { "minSlot": 22505578, "maxSlot": 22515578 }
}'

curl -X "POST" "http://localhost:3000/asset/utxos" \
     -H 'Content-Type: application/json; charset=utf-8' \
     -d $'{
  "policyIds": ["919d4c2c9455016289341b1a14dedf697687af31751170d56a31466e"],
  "range": { "minSlot": 22505578, "maxSlot": 22515578 }
}'

curl -X "POST" "http://localhost:3000/asset/utxos" \
     -H 'Content-Type: application/json; charset=utf-8' \
     -d $'{
  "policyIds": ["919d4c2c9455016289341b1a14dedf697687af31751170d56a31466e"],
  "fingerprints": ["asset1dgp85pz2m6pcs43jmkdy0fctngm56s9xd9kleg"],
  "range": { "minSlot": 35939453, "maxSlot": 35939853 }
}'
```

Also the policy id and asset name are added to the output, so that it's possible to index by policy id, for example. The fingerprint could be computed from those, but it's kept anyway to avoid that extra step.