### PR TITLE
mintBurnHistory endpoint: add addresses (credentials) to the output

### DIFF
--- a/docs/bin/openapi.json
+++ b/docs/bin/openapi.json
@@ -917,6 +917,78 @@
                         "description": "Slot at which the transaction happened",
                         "example": 512345
                     },
+                    "outputAddresses": {
+                        "properties": {},
+                        "additionalProperties": {
+                            "items": {
+                                "properties": {
+                                    "amount": {
+                                        "$ref": "#/components/schemas/Amount"
+                                    },
+                                    "assetName": {
+                                        "$ref": "#/components/schemas/AssetName"
+                                    },
+                                    "policyId": {
+                                        "$ref": "#/components/schemas/PolicyId"
+                                    }
+                                },
+                                "required": [
+                                    "amount",
+                                    "assetName",
+                                    "policyId"
+                                ],
+                                "type": "object"
+                            },
+                            "type": "array"
+                        },
+                        "type": "object",
+                        "description": "Output parts indexed by address. This mapping will only contain assets that\nwere minted or burned in this transaction.",
+                        "example": {
+                            "8200581c4b2e7295ac876cfdf70e82c1cb8df3ee5cb23d93949e3322230fc447": [
+                                {
+                                    "policyId": "b863bc7369f46136ac1048adb2fa7dae3af944c3bbb2be2f216a8d4f",
+                                    "assetName": "42657272794e617679",
+                                    "amount": "1"
+                                }
+                            ]
+                        }
+                    },
+                    "inputAddresses": {
+                        "properties": {},
+                        "additionalProperties": {
+                            "items": {
+                                "properties": {
+                                    "amount": {
+                                        "$ref": "#/components/schemas/Amount"
+                                    },
+                                    "assetName": {
+                                        "$ref": "#/components/schemas/AssetName"
+                                    },
+                                    "policyId": {
+                                        "$ref": "#/components/schemas/PolicyId"
+                                    }
+                                },
+                                "required": [
+                                    "amount",
+                                    "assetName",
+                                    "policyId"
+                                ],
+                                "type": "object"
+                            },
+                            "type": "array"
+                        },
+                        "type": "object",
+                        "description": "Input parts indexed by address. This mapping will only contain assets that\nwere minted or burned in this transaction.",
+                        "example": {
+                            "8200581c4b2e7295ac876cfdf70e82c1cb8df3ee5cb23d93949e3322230fc447": [
+                                {
+                                    "policyId": "b863bc7369f46136ac1048adb2fa7dae3af944c3bbb2be2f216a8d4f",
+                                    "assetName": "42657272794e617680",
+                                    "amount": "2"
+                                }
+                            ]
+                        }
+                    },
                     "assets": {
                         "properties": {},
                         "additionalProperties": {
@@ -930,7 +1002,8 @@
                         "description": "Assets changed in a particular transaction",
                         "example": {
                             "b863bc7369f46136ac1048adb2fa7dae3af944c3bbb2be2f216a8d4f": {
-                                "42657272794e617679": "1"
+                                "42657272794e617679": "1",
+                                "42657272794e617680": "-2"
                             }
                         }
                     }
@@ -940,6 +1013,8 @@
                     "txId",
                     "metadata",
                     "actionSlot",
+                    "outputAddresses",
+                    "inputAddresses",
                     "assets"
                 ],
                 "type": "object"

--- a/webserver/server/app/models/asset/mintBurnHistory.queries.ts
+++ b/webserver/server/app/models/asset/mintBurnHistory.queries.ts
@@ -1,6 +1,8 @@
 /** Types generated for queries found in "app/models/asset/mintBurnHistory.sql" */
 import { PreparedQuery } from '@pgtyped/runtime';
 
+export type BufferArray = (Buffer)[];
+
 export type Json = null | boolean | number | string | Json[] | { [key: string]: Json };
 
 export type NumberOrString = number | string;
@@ -17,6 +19,8 @@ export interface ISqlMintBurnRangeResult {
   action_slot: number;
   action_tx_metadata: string | null;
   block: string;
+  input_payloads: BufferArray | null;
+  output_payloads: BufferArray | null;
   payload: Json;
   tx: string;
 }
@@ -27,7 +31,7 @@ export interface ISqlMintBurnRangeQuery {
   result: ISqlMintBurnRangeResult;
 }
 
-const sqlMintBurnRangeIR: any = {"usedParamSet":{"after_tx_id":true,"until_tx_id":true,"limit":true},"params":[{"name":"after_tx_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":734,"b":746}]},{"name":"until_tx_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":773,"b":785}]},{"name":"limit","required":true,"transform":{"type":"scalar"},"locs":[{"a":887,"b":893}]}],"statement":"SELECT\n\tENCODE(\"Transaction\".HASH, 'hex') \"tx!\",\n\tENCODE(\"Block\".HASH, 'hex') AS \"block!\",\n\t\"Block\".slot AS action_slot,\n\tENCODE(\"TransactionMetadata\".payload, 'hex') as action_tx_metadata,\n\tjson_agg(json_build_object(\n        'amount', \"AssetMint\".amount::text,\n        'policyId', encode(\"NativeAsset\".policy_id, 'hex'),\n        'assetName', encode(\"NativeAsset\".asset_name, 'hex')\n\t)) as \"payload!\"\nFROM \"AssetMint\"\n         LEFT JOIN \"TransactionMetadata\" ON \"TransactionMetadata\".id = \"AssetMint\".tx_id\n         JOIN \"NativeAsset\" ON \"NativeAsset\".id = \"AssetMint\".asset_id\n         JOIN \"Transaction\" ON \"Transaction\".id = \"AssetMint\".tx_id\n         JOIN \"Block\" ON \"Transaction\".block_id = \"Block\".id\nWHERE\n\t\"Transaction\".id > :after_tx_id! AND\n\t\"Transaction\".id <= :until_tx_id!\nGROUP BY \"Transaction\".id, \"Block\".id, \"TransactionMetadata\".id\nORDER BY \"Transaction\".id ASC\nLIMIT :limit!"};
+const sqlMintBurnRangeIR: any = {"usedParamSet":{"after_tx_id":true,"until_tx_id":true,"limit":true},"params":[{"name":"after_tx_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":1118,"b":1130}]},{"name":"until_tx_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":1157,"b":1169}]},{"name":"limit","required":true,"transform":{"type":"scalar"},"locs":[{"a":1271,"b":1277}]}],"statement":"SELECT\n\tENCODE(\"Transaction\".HASH, 'hex') \"tx!\",\n\tENCODE(\"Block\".HASH, 'hex') AS \"block!\",\n\t\"Block\".slot AS action_slot,\n\tENCODE(\"TransactionMetadata\".payload, 'hex') as action_tx_metadata,\n\tjson_agg(json_build_object(\n        'amount', \"AssetMint\".amount::text,\n        'policyId', encode(\"NativeAsset\".policy_id, 'hex'),\n        'assetName', encode(\"NativeAsset\".asset_name, 'hex')\n\t)) as \"payload!\",\n\tarray_agg(DISTINCT \"TransactionOutput\".payload) as output_payloads,\n\tarray_agg(DISTINCT input_outputs.payload) input_payloads\nFROM \"AssetMint\"\n         LEFT JOIN \"TransactionMetadata\" ON \"TransactionMetadata\".id = \"AssetMint\".tx_id\n         JOIN \"NativeAsset\" ON \"NativeAsset\".id = \"AssetMint\".asset_id\n         JOIN \"Transaction\" ON \"Transaction\".id = \"AssetMint\".tx_id\n         JOIN \"Block\" ON \"Transaction\".block_id = \"Block\".id\n\t\t LEFT JOIN \"TransactionOutput\" ON \"TransactionOutput\".tx_id = \"Transaction\".id\n\t\t LEFT JOIN \"TransactionInput\" ON \"TransactionInput\".tx_id = \"Transaction\".id\n\t\t LEFT JOIN \"TransactionOutput\" input_outputs ON \"TransactionInput\".utxo_id = input_outputs.id\nWHERE\n\t\"Transaction\".id > :after_tx_id! AND\n\t\"Transaction\".id <= :until_tx_id!\nGROUP BY \"Transaction\".id, \"Block\".id, \"TransactionMetadata\".id\nORDER BY \"Transaction\".id ASC\nLIMIT :limit!"};
 
 /**
  * Query generated from SQL:
@@ -41,12 +45,17 @@ const sqlMintBurnRangeIR: any = {"usedParamSet":{"after_tx_id":true,"until_tx_id
  *         'amount', "AssetMint".amount::text,
  *         'policyId', encode("NativeAsset".policy_id, 'hex'),
  *         'assetName', encode("NativeAsset".asset_name, 'hex')
- * 	)) as "payload!"
+ * 	)) as "payload!",
+ * 	array_agg(DISTINCT "TransactionOutput".payload) as output_payloads,
+ * 	array_agg(DISTINCT input_outputs.payload) input_payloads
  * FROM "AssetMint"
  *          LEFT JOIN "TransactionMetadata" ON "TransactionMetadata".id = "AssetMint".tx_id
  *          JOIN "NativeAsset" ON "NativeAsset".id = "AssetMint".asset_id
  *          JOIN "Transaction" ON "Transaction".id = "AssetMint".tx_id
  *          JOIN "Block" ON "Transaction".block_id = "Block".id
+ * 		 LEFT JOIN "TransactionOutput" ON "TransactionOutput".tx_id = "Transaction".id
+ * 		 LEFT JOIN "TransactionInput" ON "TransactionInput".tx_id = "Transaction".id
+ * 		 LEFT JOIN "TransactionOutput" input_outputs ON "TransactionInput".utxo_id = input_outputs.id
  * WHERE
  * 	"Transaction".id > :after_tx_id! AND
  * 	"Transaction".id <= :until_tx_id!
@@ -71,6 +80,8 @@ export interface ISqlMintBurnRangeByPolicyIdsResult {
   action_slot: number;
   action_tx_metadata: string | null;
   block: string;
+  input_payloads: BufferArray | null;
+  output_payloads: BufferArray | null;
   payload: Json;
   tx: string;
 }
@@ -81,7 +92,7 @@ export interface ISqlMintBurnRangeByPolicyIdsQuery {
   result: ISqlMintBurnRangeByPolicyIdsResult;
 }
 
-const sqlMintBurnRangeByPolicyIdsIR: any = {"usedParamSet":{"after_tx_id":true,"until_tx_id":true,"policy_ids":true,"limit":true},"params":[{"name":"policy_ids","required":true,"transform":{"type":"array_spread"},"locs":[{"a":822,"b":833}]},{"name":"after_tx_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":734,"b":746}]},{"name":"until_tx_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":773,"b":785}]},{"name":"limit","required":true,"transform":{"type":"scalar"},"locs":[{"a":935,"b":941}]}],"statement":"SELECT\n\tENCODE(\"Transaction\".HASH, 'hex') \"tx!\",\n\tENCODE(\"Block\".HASH, 'hex') AS \"block!\",\n\t\"Block\".slot AS action_slot,\n\tENCODE(\"TransactionMetadata\".payload, 'hex') as action_tx_metadata,\n\tjson_agg(json_build_object(\n        'amount', \"AssetMint\".amount::text,\n        'policyId', encode(\"NativeAsset\".policy_id, 'hex'),\n        'assetName', encode(\"NativeAsset\".asset_name, 'hex')\n\t)) as \"payload!\"\nFROM \"AssetMint\"\n         LEFT JOIN \"TransactionMetadata\" ON \"TransactionMetadata\".id = \"AssetMint\".tx_id\n         JOIN \"NativeAsset\" ON \"NativeAsset\".id = \"AssetMint\".asset_id\n         JOIN \"Transaction\" ON \"Transaction\".id = \"AssetMint\".tx_id\n         JOIN \"Block\" ON \"Transaction\".block_id = \"Block\".id\nWHERE\n\t\"Transaction\".id > :after_tx_id! AND\n\t\"Transaction\".id <= :until_tx_id!\n    AND \"NativeAsset\".policy_id IN :policy_ids!\nGROUP BY \"Transaction\".id, \"Block\".id, \"TransactionMetadata\".id\nORDER BY \"Transaction\".id ASC\nLIMIT :limit!"};
+const sqlMintBurnRangeByPolicyIdsIR: any = {"usedParamSet":{"after_tx_id":true,"until_tx_id":true,"policy_ids":true,"limit":true},"params":[{"name":"policy_ids","required":true,"transform":{"type":"array_spread"},"locs":[{"a":1206,"b":1217}]},{"name":"after_tx_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":1118,"b":1130}]},{"name":"until_tx_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":1157,"b":1169}]},{"name":"limit","required":true,"transform":{"type":"scalar"},"locs":[{"a":1319,"b":1325}]}],"statement":"SELECT\n\tENCODE(\"Transaction\".HASH, 'hex') \"tx!\",\n\tENCODE(\"Block\".HASH, 'hex') AS \"block!\",\n\t\"Block\".slot AS action_slot,\n\tENCODE(\"TransactionMetadata\".payload, 'hex') as action_tx_metadata,\n\tjson_agg(json_build_object(\n        'amount', \"AssetMint\".amount::text,\n        'policyId', encode(\"NativeAsset\".policy_id, 'hex'),\n        'assetName', encode(\"NativeAsset\".asset_name, 'hex')\n\t)) as \"payload!\",\n\tarray_agg(DISTINCT \"TransactionOutput\".payload) as output_payloads,\n\tarray_agg(DISTINCT input_outputs.payload) input_payloads\nFROM \"AssetMint\"\n         LEFT JOIN \"TransactionMetadata\" ON \"TransactionMetadata\".id = \"AssetMint\".tx_id\n         JOIN \"NativeAsset\" ON \"NativeAsset\".id = \"AssetMint\".asset_id\n         JOIN \"Transaction\" ON \"Transaction\".id = \"AssetMint\".tx_id\n         JOIN \"Block\" ON \"Transaction\".block_id = \"Block\".id\n\t\t LEFT JOIN \"TransactionOutput\" ON \"TransactionOutput\".tx_id = \"Transaction\".id\n\t\t LEFT JOIN \"TransactionInput\" ON \"TransactionInput\".tx_id = \"Transaction\".id\n\t\t LEFT JOIN \"TransactionOutput\" input_outputs ON \"TransactionInput\".utxo_id = input_outputs.id\nWHERE\n\t\"Transaction\".id > :after_tx_id! AND\n\t\"Transaction\".id <= :until_tx_id!\n    AND \"NativeAsset\".policy_id IN :policy_ids!\nGROUP BY \"Transaction\".id, \"Block\".id, \"TransactionMetadata\".id\nORDER BY \"Transaction\".id ASC\nLIMIT :limit!"};
 
 /**
  * Query generated from SQL:
@@ -95,12 +106,17 @@ const sqlMintBurnRangeByPolicyIdsIR: any = {"usedParamSet":{"after_tx_id":true,"
  *         'amount', "AssetMint".amount::text,
  *         'policyId', encode("NativeAsset".policy_id, 'hex'),
  *         'assetName', encode("NativeAsset".asset_name, 'hex')
- * 	)) as "payload!"
+ * 	)) as "payload!",
+ * 	array_agg(DISTINCT "TransactionOutput".payload) as output_payloads,
+ * 	array_agg(DISTINCT input_outputs.payload) input_payloads
  * FROM "AssetMint"
  *          LEFT JOIN "TransactionMetadata" ON "TransactionMetadata".id = "AssetMint".tx_id
  *          JOIN "NativeAsset" ON "NativeAsset".id = "AssetMint".asset_id
  *          JOIN "Transaction" ON "Transaction".id = "AssetMint".tx_id
  *          JOIN "Block" ON "Transaction".block_id = "Block".id
+ * 		 LEFT JOIN "TransactionOutput" ON "TransactionOutput".tx_id = "Transaction".id
+ * 		 LEFT JOIN "TransactionInput" ON "TransactionInput".tx_id = "Transaction".id
+ * 		 LEFT JOIN "TransactionOutput" input_outputs ON "TransactionInput".utxo_id = input_outputs.id
  * WHERE
  * 	"Transaction".id > :after_tx_id! AND
  * 	"Transaction".id <= :until_tx_id!

--- a/webserver/server/app/models/asset/mintBurnHistory.queries.ts
+++ b/webserver/server/app/models/asset/mintBurnHistory.queries.ts
@@ -19,10 +19,10 @@ export interface ISqlMintBurnRangeResult {
   action_slot: number;
   action_tx_metadata: string | null;
   block: string;
-  input_payloads: BufferArray | null;
   output_payloads: BufferArray | null;
   payload: Json;
   tx: string;
+  tx_db_id: string;
 }
 
 /** 'SqlMintBurnRange' query type */
@@ -31,7 +31,7 @@ export interface ISqlMintBurnRangeQuery {
   result: ISqlMintBurnRangeResult;
 }
 
-const sqlMintBurnRangeIR: any = {"usedParamSet":{"after_tx_id":true,"until_tx_id":true,"limit":true},"params":[{"name":"after_tx_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":1118,"b":1130}]},{"name":"until_tx_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":1157,"b":1169}]},{"name":"limit","required":true,"transform":{"type":"scalar"},"locs":[{"a":1271,"b":1277}]}],"statement":"SELECT\n\tENCODE(\"Transaction\".HASH, 'hex') \"tx!\",\n\tENCODE(\"Block\".HASH, 'hex') AS \"block!\",\n\t\"Block\".slot AS action_slot,\n\tENCODE(\"TransactionMetadata\".payload, 'hex') as action_tx_metadata,\n\tjson_agg(json_build_object(\n        'amount', \"AssetMint\".amount::text,\n        'policyId', encode(\"NativeAsset\".policy_id, 'hex'),\n        'assetName', encode(\"NativeAsset\".asset_name, 'hex')\n\t)) as \"payload!\",\n\tarray_agg(DISTINCT \"TransactionOutput\".payload) as output_payloads,\n\tarray_agg(DISTINCT input_outputs.payload) input_payloads\nFROM \"AssetMint\"\n         LEFT JOIN \"TransactionMetadata\" ON \"TransactionMetadata\".id = \"AssetMint\".tx_id\n         JOIN \"NativeAsset\" ON \"NativeAsset\".id = \"AssetMint\".asset_id\n         JOIN \"Transaction\" ON \"Transaction\".id = \"AssetMint\".tx_id\n         JOIN \"Block\" ON \"Transaction\".block_id = \"Block\".id\n\t\t LEFT JOIN \"TransactionOutput\" ON \"TransactionOutput\".tx_id = \"Transaction\".id\n\t\t LEFT JOIN \"TransactionInput\" ON \"TransactionInput\".tx_id = \"Transaction\".id\n\t\t LEFT JOIN \"TransactionOutput\" input_outputs ON \"TransactionInput\".utxo_id = input_outputs.id\nWHERE\n\t\"Transaction\".id > :after_tx_id! AND\n\t\"Transaction\".id <= :until_tx_id!\nGROUP BY \"Transaction\".id, \"Block\".id, \"TransactionMetadata\".id\nORDER BY \"Transaction\".id ASC\nLIMIT :limit!"};
+const sqlMintBurnRangeIR: any = {"usedParamSet":{"after_tx_id":true,"until_tx_id":true,"limit":true},"params":[{"name":"after_tx_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":906,"b":918}]},{"name":"until_tx_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":945,"b":957}]},{"name":"limit","required":true,"transform":{"type":"scalar"},"locs":[{"a":1059,"b":1065}]}],"statement":"SELECT\n\tENCODE(\"Transaction\".HASH, 'hex') \"tx!\",\n\tENCODE(\"Block\".HASH, 'hex') AS \"block!\",\n\t\"Block\".slot AS action_slot,\n\tENCODE(\"TransactionMetadata\".payload, 'hex') as action_tx_metadata,\n\tjson_agg(json_build_object(\n        'amount', \"AssetMint\".amount::text,\n        'policyId', encode(\"NativeAsset\".policy_id, 'hex'),\n        'assetName', encode(\"NativeAsset\".asset_name, 'hex')\n\t)) as \"payload!\",\n\tarray_agg(\"TransactionOutput\".payload) as output_payloads,\n\t\"Transaction\".id as tx_db_id\nFROM \"AssetMint\"\n         LEFT JOIN \"TransactionMetadata\" ON \"TransactionMetadata\".id = \"AssetMint\".tx_id\n         JOIN \"NativeAsset\" ON \"NativeAsset\".id = \"AssetMint\".asset_id\n         JOIN \"Transaction\" ON \"Transaction\".id = \"AssetMint\".tx_id\n         JOIN \"Block\" ON \"Transaction\".block_id = \"Block\".id\n\t\t LEFT JOIN \"TransactionOutput\" ON \"TransactionOutput\".tx_id = \"Transaction\".id\nWHERE\n\t\"Transaction\".id > :after_tx_id! AND\n\t\"Transaction\".id <= :until_tx_id!\nGROUP BY \"Transaction\".id, \"Block\".id, \"TransactionMetadata\".id\nORDER BY \"Transaction\".id ASC\nLIMIT :limit!"};
 
 /**
  * Query generated from SQL:
@@ -46,16 +46,14 @@ const sqlMintBurnRangeIR: any = {"usedParamSet":{"after_tx_id":true,"until_tx_id
  *         'policyId', encode("NativeAsset".policy_id, 'hex'),
  *         'assetName', encode("NativeAsset".asset_name, 'hex')
  * 	)) as "payload!",
- * 	array_agg(DISTINCT "TransactionOutput".payload) as output_payloads,
- * 	array_agg(DISTINCT input_outputs.payload) input_payloads
+ * 	array_agg("TransactionOutput".payload) as output_payloads,
+ * 	"Transaction".id as tx_db_id
  * FROM "AssetMint"
  *          LEFT JOIN "TransactionMetadata" ON "TransactionMetadata".id = "AssetMint".tx_id
  *          JOIN "NativeAsset" ON "NativeAsset".id = "AssetMint".asset_id
  *          JOIN "Transaction" ON "Transaction".id = "AssetMint".tx_id
  *          JOIN "Block" ON "Transaction".block_id = "Block".id
  * 		 LEFT JOIN "TransactionOutput" ON "TransactionOutput".tx_id = "Transaction".id
- * 		 LEFT JOIN "TransactionInput" ON "TransactionInput".tx_id = "Transaction".id
- * 		 LEFT JOIN "TransactionOutput" input_outputs ON "TransactionInput".utxo_id = input_outputs.id
  * WHERE
  * 	"Transaction".id > :after_tx_id! AND
  * 	"Transaction".id <= :until_tx_id!
@@ -80,10 +78,10 @@ export interface ISqlMintBurnRangeByPolicyIdsResult {
   action_slot: number;
   action_tx_metadata: string | null;
   block: string;
-  input_payloads: BufferArray | null;
   output_payloads: BufferArray | null;
   payload: Json;
   tx: string;
+  tx_db_id: string;
 }
 
 /** 'SqlMintBurnRangeByPolicyIds' query type */
@@ -92,7 +90,7 @@ export interface ISqlMintBurnRangeByPolicyIdsQuery {
   result: ISqlMintBurnRangeByPolicyIdsResult;
 }
 
-const sqlMintBurnRangeByPolicyIdsIR: any = {"usedParamSet":{"after_tx_id":true,"until_tx_id":true,"policy_ids":true,"limit":true},"params":[{"name":"policy_ids","required":true,"transform":{"type":"array_spread"},"locs":[{"a":1206,"b":1217}]},{"name":"after_tx_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":1118,"b":1130}]},{"name":"until_tx_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":1157,"b":1169}]},{"name":"limit","required":true,"transform":{"type":"scalar"},"locs":[{"a":1319,"b":1325}]}],"statement":"SELECT\n\tENCODE(\"Transaction\".HASH, 'hex') \"tx!\",\n\tENCODE(\"Block\".HASH, 'hex') AS \"block!\",\n\t\"Block\".slot AS action_slot,\n\tENCODE(\"TransactionMetadata\".payload, 'hex') as action_tx_metadata,\n\tjson_agg(json_build_object(\n        'amount', \"AssetMint\".amount::text,\n        'policyId', encode(\"NativeAsset\".policy_id, 'hex'),\n        'assetName', encode(\"NativeAsset\".asset_name, 'hex')\n\t)) as \"payload!\",\n\tarray_agg(DISTINCT \"TransactionOutput\".payload) as output_payloads,\n\tarray_agg(DISTINCT input_outputs.payload) input_payloads\nFROM \"AssetMint\"\n         LEFT JOIN \"TransactionMetadata\" ON \"TransactionMetadata\".id = \"AssetMint\".tx_id\n         JOIN \"NativeAsset\" ON \"NativeAsset\".id = \"AssetMint\".asset_id\n         JOIN \"Transaction\" ON \"Transaction\".id = \"AssetMint\".tx_id\n         JOIN \"Block\" ON \"Transaction\".block_id = \"Block\".id\n\t\t LEFT JOIN \"TransactionOutput\" ON \"TransactionOutput\".tx_id = \"Transaction\".id\n\t\t LEFT JOIN \"TransactionInput\" ON \"TransactionInput\".tx_id = \"Transaction\".id\n\t\t LEFT JOIN \"TransactionOutput\" input_outputs ON \"TransactionInput\".utxo_id = input_outputs.id\nWHERE\n\t\"Transaction\".id > :after_tx_id! AND\n\t\"Transaction\".id <= :until_tx_id!\n    AND \"NativeAsset\".policy_id IN :policy_ids!\nGROUP BY \"Transaction\".id, \"Block\".id, \"TransactionMetadata\".id\nORDER BY \"Transaction\".id ASC\nLIMIT :limit!"};
+const sqlMintBurnRangeByPolicyIdsIR: any = {"usedParamSet":{"after_tx_id":true,"until_tx_id":true,"policy_ids":true,"limit":true},"params":[{"name":"policy_ids","required":true,"transform":{"type":"array_spread"},"locs":[{"a":994,"b":1005}]},{"name":"after_tx_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":906,"b":918}]},{"name":"until_tx_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":945,"b":957}]},{"name":"limit","required":true,"transform":{"type":"scalar"},"locs":[{"a":1107,"b":1113}]}],"statement":"SELECT\n\tENCODE(\"Transaction\".HASH, 'hex') \"tx!\",\n\tENCODE(\"Block\".HASH, 'hex') AS \"block!\",\n\t\"Block\".slot AS action_slot,\n\tENCODE(\"TransactionMetadata\".payload, 'hex') as action_tx_metadata,\n\tjson_agg(json_build_object(\n        'amount', \"AssetMint\".amount::text,\n        'policyId', encode(\"NativeAsset\".policy_id, 'hex'),\n        'assetName', encode(\"NativeAsset\".asset_name, 'hex')\n\t)) as \"payload!\",\n\tarray_agg(\"TransactionOutput\".payload) as output_payloads,\n\t\"Transaction\".id as tx_db_id\nFROM \"AssetMint\"\n         LEFT JOIN \"TransactionMetadata\" ON \"TransactionMetadata\".id = \"AssetMint\".tx_id\n         JOIN \"NativeAsset\" ON \"NativeAsset\".id = \"AssetMint\".asset_id\n         JOIN \"Transaction\" ON \"Transaction\".id = \"AssetMint\".tx_id\n         JOIN \"Block\" ON \"Transaction\".block_id = \"Block\".id\n\t\t LEFT JOIN \"TransactionOutput\" ON \"TransactionOutput\".tx_id = \"Transaction\".id\nWHERE\n\t\"Transaction\".id > :after_tx_id! AND\n\t\"Transaction\".id <= :until_tx_id! AND\n    \"NativeAsset\".policy_id IN :policy_ids!\nGROUP BY \"Transaction\".id, \"Block\".id, \"TransactionMetadata\".id\nORDER BY \"Transaction\".id ASC\nLIMIT :limit!"};
 
 /**
  * Query generated from SQL:
@@ -107,25 +105,57 @@ const sqlMintBurnRangeByPolicyIdsIR: any = {"usedParamSet":{"after_tx_id":true,"
  *         'policyId', encode("NativeAsset".policy_id, 'hex'),
  *         'assetName', encode("NativeAsset".asset_name, 'hex')
  * 	)) as "payload!",
- * 	array_agg(DISTINCT "TransactionOutput".payload) as output_payloads,
- * 	array_agg(DISTINCT input_outputs.payload) input_payloads
+ * 	array_agg("TransactionOutput".payload) as output_payloads,
+ * 	"Transaction".id as tx_db_id
  * FROM "AssetMint"
  *          LEFT JOIN "TransactionMetadata" ON "TransactionMetadata".id = "AssetMint".tx_id
  *          JOIN "NativeAsset" ON "NativeAsset".id = "AssetMint".asset_id
  *          JOIN "Transaction" ON "Transaction".id = "AssetMint".tx_id
  *          JOIN "Block" ON "Transaction".block_id = "Block".id
  * 		 LEFT JOIN "TransactionOutput" ON "TransactionOutput".tx_id = "Transaction".id
- * 		 LEFT JOIN "TransactionInput" ON "TransactionInput".tx_id = "Transaction".id
- * 		 LEFT JOIN "TransactionOutput" input_outputs ON "TransactionInput".utxo_id = input_outputs.id
  * WHERE
  * 	"Transaction".id > :after_tx_id! AND
- * 	"Transaction".id <= :until_tx_id!
- *     AND "NativeAsset".policy_id IN :policy_ids!
+ * 	"Transaction".id <= :until_tx_id! AND
+ *     "NativeAsset".policy_id IN :policy_ids!
  * GROUP BY "Transaction".id, "Block".id, "TransactionMetadata".id
  * ORDER BY "Transaction".id ASC
  * LIMIT :limit!
  * ```
  */
 export const sqlMintBurnRangeByPolicyIds = new PreparedQuery<ISqlMintBurnRangeByPolicyIdsParams,ISqlMintBurnRangeByPolicyIdsResult>(sqlMintBurnRangeByPolicyIdsIR);
+
+
+/** 'GetTransactionInputs' parameters type */
+export interface IGetTransactionInputsParams {
+  tx_ids: readonly (NumberOrString)[];
+}
+
+/** 'GetTransactionInputs' return type */
+export interface IGetTransactionInputsResult {
+  input_payloads: BufferArray | null;
+  tx_id: string;
+}
+
+/** 'GetTransactionInputs' query type */
+export interface IGetTransactionInputsQuery {
+  params: IGetTransactionInputsParams;
+  result: IGetTransactionInputsResult;
+}
+
+const getTransactionInputsIR: any = {"usedParamSet":{"tx_ids":true},"params":[{"name":"tx_ids","required":true,"transform":{"type":"array_spread"},"locs":[{"a":226,"b":233}]}],"statement":"SELECT\n\tarray_agg(\"TransactionOutput\".payload) input_payloads, \"TransactionInput\".tx_id\nFROM \"TransactionInput\"\nJOIN \"TransactionOutput\" ON \"TransactionInput\".utxo_id = \"TransactionOutput\".id\nWHERE \"TransactionInput\".tx_id in :tx_ids!\nGROUP BY \"TransactionInput\".tx_id\nLIMIT 100"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT
+ * 	array_agg("TransactionOutput".payload) input_payloads, "TransactionInput".tx_id
+ * FROM "TransactionInput"
+ * JOIN "TransactionOutput" ON "TransactionInput".utxo_id = "TransactionOutput".id
+ * WHERE "TransactionInput".tx_id in :tx_ids!
+ * GROUP BY "TransactionInput".tx_id
+ * LIMIT 100
+ * ```
+ */
+export const getTransactionInputs = new PreparedQuery<IGetTransactionInputsParams,IGetTransactionInputsResult>(getTransactionInputsIR);
 
 

--- a/webserver/server/app/models/asset/mintBurnHistory.sql
+++ b/webserver/server/app/models/asset/mintBurnHistory.sql
@@ -10,12 +10,17 @@ SELECT
         'amount', "AssetMint".amount::text,
         'policyId', encode("NativeAsset".policy_id, 'hex'),
         'assetName', encode("NativeAsset".asset_name, 'hex')
-	)) as "payload!"
+	)) as "payload!",
+	array_agg(DISTINCT "TransactionOutput".payload) as output_payloads,
+	array_agg(DISTINCT input_outputs.payload) input_payloads
 FROM "AssetMint"
          LEFT JOIN "TransactionMetadata" ON "TransactionMetadata".id = "AssetMint".tx_id
          JOIN "NativeAsset" ON "NativeAsset".id = "AssetMint".asset_id
          JOIN "Transaction" ON "Transaction".id = "AssetMint".tx_id
          JOIN "Block" ON "Transaction".block_id = "Block".id
+		 LEFT JOIN "TransactionOutput" ON "TransactionOutput".tx_id = "Transaction".id
+		 LEFT JOIN "TransactionInput" ON "TransactionInput".tx_id = "Transaction".id
+		 LEFT JOIN "TransactionOutput" input_outputs ON "TransactionInput".utxo_id = input_outputs.id
 WHERE
 	"Transaction".id > :after_tx_id! AND
 	"Transaction".id <= :until_tx_id!
@@ -36,12 +41,17 @@ SELECT
         'amount', "AssetMint".amount::text,
         'policyId', encode("NativeAsset".policy_id, 'hex'),
         'assetName', encode("NativeAsset".asset_name, 'hex')
-	)) as "payload!"
+	)) as "payload!",
+	array_agg(DISTINCT "TransactionOutput".payload) as output_payloads,
+	array_agg(DISTINCT input_outputs.payload) input_payloads
 FROM "AssetMint"
          LEFT JOIN "TransactionMetadata" ON "TransactionMetadata".id = "AssetMint".tx_id
          JOIN "NativeAsset" ON "NativeAsset".id = "AssetMint".asset_id
          JOIN "Transaction" ON "Transaction".id = "AssetMint".tx_id
          JOIN "Block" ON "Transaction".block_id = "Block".id
+		 LEFT JOIN "TransactionOutput" ON "TransactionOutput".tx_id = "Transaction".id
+		 LEFT JOIN "TransactionInput" ON "TransactionInput".tx_id = "Transaction".id
+		 LEFT JOIN "TransactionOutput" input_outputs ON "TransactionInput".utxo_id = input_outputs.id
 WHERE
 	"Transaction".id > :after_tx_id! AND
 	"Transaction".id <= :until_tx_id!

--- a/webserver/server/app/models/asset/mintBurnHistory.sql
+++ b/webserver/server/app/models/asset/mintBurnHistory.sql
@@ -11,16 +11,14 @@ SELECT
         'policyId', encode("NativeAsset".policy_id, 'hex'),
         'assetName', encode("NativeAsset".asset_name, 'hex')
 	)) as "payload!",
-	array_agg(DISTINCT "TransactionOutput".payload) as output_payloads,
-	array_agg(DISTINCT input_outputs.payload) input_payloads
+	array_agg("TransactionOutput".payload) as output_payloads,
+	"Transaction".id as tx_db_id
 FROM "AssetMint"
          LEFT JOIN "TransactionMetadata" ON "TransactionMetadata".id = "AssetMint".tx_id
          JOIN "NativeAsset" ON "NativeAsset".id = "AssetMint".asset_id
          JOIN "Transaction" ON "Transaction".id = "AssetMint".tx_id
          JOIN "Block" ON "Transaction".block_id = "Block".id
 		 LEFT JOIN "TransactionOutput" ON "TransactionOutput".tx_id = "Transaction".id
-		 LEFT JOIN "TransactionInput" ON "TransactionInput".tx_id = "Transaction".id
-		 LEFT JOIN "TransactionOutput" input_outputs ON "TransactionInput".utxo_id = input_outputs.id
 WHERE
 	"Transaction".id > :after_tx_id! AND
 	"Transaction".id <= :until_tx_id!
@@ -42,20 +40,30 @@ SELECT
         'policyId', encode("NativeAsset".policy_id, 'hex'),
         'assetName', encode("NativeAsset".asset_name, 'hex')
 	)) as "payload!",
-	array_agg(DISTINCT "TransactionOutput".payload) as output_payloads,
-	array_agg(DISTINCT input_outputs.payload) input_payloads
+	array_agg("TransactionOutput".payload) as output_payloads,
+	"Transaction".id as tx_db_id
 FROM "AssetMint"
          LEFT JOIN "TransactionMetadata" ON "TransactionMetadata".id = "AssetMint".tx_id
          JOIN "NativeAsset" ON "NativeAsset".id = "AssetMint".asset_id
          JOIN "Transaction" ON "Transaction".id = "AssetMint".tx_id
          JOIN "Block" ON "Transaction".block_id = "Block".id
 		 LEFT JOIN "TransactionOutput" ON "TransactionOutput".tx_id = "Transaction".id
-		 LEFT JOIN "TransactionInput" ON "TransactionInput".tx_id = "Transaction".id
-		 LEFT JOIN "TransactionOutput" input_outputs ON "TransactionInput".utxo_id = input_outputs.id
 WHERE
 	"Transaction".id > :after_tx_id! AND
-	"Transaction".id <= :until_tx_id!
-    AND "NativeAsset".policy_id IN :policy_ids!
+	"Transaction".id <= :until_tx_id! AND
+    "NativeAsset".policy_id IN :policy_ids!
 GROUP BY "Transaction".id, "Block".id, "TransactionMetadata".id
 ORDER BY "Transaction".id ASC
 LIMIT :limit!;
+
+/*
+@name getTransactionInputs
+@param tx_ids -> (...)
+*/
+SELECT
+	array_agg("TransactionOutput".payload) input_payloads, "TransactionInput".tx_id
+FROM "TransactionInput"
+JOIN "TransactionOutput" ON "TransactionInput".utxo_id = "TransactionOutput".id
+WHERE "TransactionInput".tx_id in :tx_ids!
+GROUP BY "TransactionInput".tx_id
+LIMIT 100;

--- a/webserver/shared/models/MintBurn.ts
+++ b/webserver/shared/models/MintBurn.ts
@@ -15,11 +15,35 @@ export type MintBurnSingleResponse = {
   /**
    * Assets changed in a particular transaction
    *
-   * @example { "b863bc7369f46136ac1048adb2fa7dae3af944c3bbb2be2f216a8d4f": { "42657272794e617679": "1" }}
+   * @example { "b863bc7369f46136ac1048adb2fa7dae3af944c3bbb2be2f216a8d4f":
+   *    {
+   *      "42657272794e617679": "1",
+   *      "42657272794e617680": "-2"
+   *    }
+   * }
    */
   assets: { [policyId: string]: { [assetName: string]: Amount } };
 
+  /**
+   * Input parts indexed by address. This mapping will only contain assets that
+   * were minted or burned in this transaction.
+   *
+   * @example {
+   *  "8200581c4b2e7295ac876cfdf70e82c1cb8df3ee5cb23d93949e3322230fc447":
+   *    [ { "policyId": "b863bc7369f46136ac1048adb2fa7dae3af944c3bbb2be2f216a8d4f", "assetName": "42657272794e617680", "amount": "2" } ]
+   * }
+   */
   inputAddresses: { [address: string]: {policyId: PolicyId, assetName: AssetName, amount: Amount}[]}
+
+  /**
+   * Output parts indexed by address. This mapping will only contain assets that
+   * were minted or burned in this transaction.
+   *
+   * @example {
+   *  "8200581c4b2e7295ac876cfdf70e82c1cb8df3ee5cb23d93949e3322230fc447":
+   *    [ { "policyId": "b863bc7369f46136ac1048adb2fa7dae3af944c3bbb2be2f216a8d4f", "assetName": "42657272794e617679", "amount": "1" } ]
+   * }
+   */
   outputAddresses: { [address: string]: {policyId: PolicyId, assetName: AssetName, amount: Amount}[]}
 
   /**

--- a/webserver/shared/models/MintBurn.ts
+++ b/webserver/shared/models/MintBurn.ts
@@ -1,4 +1,4 @@
-import { PolicyId } from "./PolicyIdAssetMap";
+import { PolicyId, AssetName } from "./PolicyIdAssetMap";
 import { Amount, Pagination, SlotLimits } from "./common";
 
 export type MintBurnHistoryRequest = {
@@ -18,6 +18,9 @@ export type MintBurnSingleResponse = {
    * @example { "b863bc7369f46136ac1048adb2fa7dae3af944c3bbb2be2f216a8d4f": { "42657272794e617679": "1" }}
    */
   assets: { [policyId: string]: { [assetName: string]: Amount } };
+
+  inputAddresses: { [address: string]: {policyId: PolicyId, assetName: AssetName, amount: Amount}[]}
+  outputAddresses: { [address: string]: {policyId: PolicyId, assetName: AssetName, amount: Amount}[]}
 
   /**
    * Slot at which the transaction happened


### PR DESCRIPTION
context here: https://github.com/PaimaStudios/paima-engine/issues/326

I'm not super convinced about the query yet (it works, but I'm not sure about the `distinct`), but I want to define the api first.

This adds two fields to the response in the mint burn history endpoint.

The idea is that burns would look like this:

```json
  {
    "assets": {
      "0fc891fb7368d3b7c7b88815c203fda0d6862b0f1d797222672e91fe": {
        "546f6b656e31": "-500"
      }
    },
    "actionSlot": 733071,
    "metadata": "...",
    "txId": "58e4166f029f8da36172db20d9089b5930109584fc4331641a694438a513090d",
    "block": "3bf59edcb5114d492ecd8e41792cd8fd4bf14a8569e80bf93d7141cf9621729c",
    "inputAddresses": {
      "8200581ca44a4b45469f41af5f61fcfe2098e3230b935ee074fcf0f202654c62": [
        {
          "policyId": "0fc891fb7368d3b7c7b88815c203fda0d6862b0f1d797222672e91fe",
          "assetName": "546f6b656e31",
          "amount": "500"
        }
      ]
    },
    "outputAddresses": {}
  }
```

while mints would look like:

```json
  {
    "assets": {
      "0fc891fb7368d3b7c7b88815c203fda0d6862b0f1d797222672e91fe": {
        "546f6b656e4d6574616461746132": "1",
        "546f6b656e4d6574616461746131": "1"
      }
    },
    "actionSlot": 733097,
    "metadata": "...",
    "txId": "98a9eeb50ee68a2dcb461bbcdf115ee5b395ff797f2904c6ddca7ffb449dc2ec",
    "block": "0425becb95ea75aa7c6e19b7a36046dc9d976ddfc239b30126fabd306a96ecf1",
    "inputAddresses": {},
    "outputAddresses": {
      "8200581c4b2e7295ac876cfdf70e82c1cb8df3ee5cb23d93949e3322230fc447": [
        {
          "policyId": "0fc891fb7368d3b7c7b88815c203fda0d6862b0f1d797222672e91fe",
          "assetName": "546f6b656e4d6574616461746131",
          "amount": "1"
        }
      ],
      "8200581c9f07ae02672368b23c0ea38fe4272e3a8fe5c7a34948121ad2489968": [
        {
          "policyId": "0fc891fb7368d3b7c7b88815c203fda0d6862b0f1d797222672e91fe",
          "assetName": "546f6b656e4d6574616461746132",
          "amount": "1"
        }
      ]
    }
  }
```

Currently the order in the two mappings is unspecified. I'm not really sure if it matters or not. The amount are included mostly because I think there could be extra non-minting inputs, for example, and that makes it more clear?