### PR TITLE
De-duplicate database_url between ENV and config.ymls

### DIFF
--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -45,14 +45,21 @@ pub struct Cli {
 #[serde(tag = "type", rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
 pub enum DbConfig {
-    Postgres { database_url: String },
+    Postgres {
+        #[serde(default = "get_env_db_url")]
+        database_url: String
+    },
 }
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
 pub enum SinkConfig {
-    Cardano { db: DbConfig, network: String },
+    Cardano {
+        db: DbConfig,
+        #[serde(default = "get_env_network")]
+        network: String,
+    },
 }
 
 pub enum Network {}
@@ -74,6 +81,16 @@ pub struct Config {
     /// Starting block hash. This will NOT rollback the database (use the rollback util for that)
     /// This is instead meant to make it easier to write database migrations
     start_block: Option<String>,
+}
+
+fn get_env_db_url() -> String {
+    std::env::var("DATABASE_URL")
+        .expect("env DATABASE_URL not found and config did not specify sink.db.database_url")
+}
+
+fn get_env_network() -> String {
+    std::env::var("NETWORK")
+        .expect("env NETWORK not found and config did not specify sink.network")
 }
 
 #[allow(unreachable_patterns)]

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -47,7 +47,7 @@ pub struct Cli {
 pub enum DbConfig {
     Postgres {
         #[serde(default = "get_env_db_url")]
-        database_url: String
+        database_url: String,
     },
 }
 
@@ -89,8 +89,7 @@ fn get_env_db_url() -> String {
 }
 
 fn get_env_network() -> String {
-    std::env::var("NETWORK")
-        .expect("env NETWORK not found and config did not specify sink.network")
+    std::env::var("NETWORK").expect("env NETWORK not found and config did not specify sink.network")
 }
 
 #[allow(unreachable_patterns)]


### PR DESCRIPTION
Fixes #190

Carp will now make the config's database_url optional, and if it is not present, will try and default to the DATABASE_URL env variable which is set dynamically.

Also de-duplicates the `nettwork`/`NETWORK` in the same way.

TODO: docs update?